### PR TITLE
#169: fixed error when running on cpu and added post install command to upgrade transformers

### DIFF
--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -1,6 +1,15 @@
 import setuptools
+from setuptools.command.install import install
+import subprocess
 
-with open("README.md", "r") as fh:
+# upgrade transformers to latest version to avoid "`rope_scaling` must be a dictionary with two fields" error
+class PostInstallCommand(install):
+    def run(self):
+        install.run(self)
+        subprocess.check_call(["pip", "install", "--upgrade", "transformers"])
+
+# Windows uses a different default encoding (use a consistent encoding)
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
@@ -24,6 +33,9 @@ setuptools.setup(
         'scipy',
         #'bitsandbytes' set it to optional to support fallback when not installable
     ],
+    cmdclass={
+        'install': PostInstallCommand,
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
addressing issue: #169

changelog:

1. reading README.md file in setup.py with utf-8 encoding as some systems may use different default text encoding
2. added checking for device type to ensure only cuda supported devices will use torch.cuda.Stream() and pin_memory(). this will resolve errors that occur during inferencing on cpu only devices.
3. added post install command to upgrade transformers to latest version to ensure "ValueError: `rope_scaling` must be a dictionary with two fields" error does not occur.
4. added the support for non sharded models on huggingface repo which are just single model files like 'model.safetensors'.