### PR TITLE
Fix pip not found when install in Jupyter

### DIFF
--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -10,7 +10,7 @@ class PostInstallCommand(install):
         try:
             subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "transformers"])
         except subprocess.CalledProcessError:
-            print("警告：無法升級 transformers 套件。請手動升級。")
+            print("Warning: Unable to upgrade transformers package. Please upgrade manually.")
 
 # Windows uses a different default encoding (use a consistent encoding)
 with open("README.md", "r", encoding="utf-8") as fh:

--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -1,3 +1,4 @@
+import sys
 import setuptools
 from setuptools.command.install import install
 import subprocess
@@ -6,7 +7,10 @@ import subprocess
 class PostInstallCommand(install):
     def run(self):
         install.run(self)
-        subprocess.check_call(["pip", "install", "--upgrade", "transformers"])
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "transformers"])
+        except subprocess.CalledProcessError:
+            print("警告：無法升級 transformers 套件。請手動升級。")
 
 # Windows uses a different default encoding (use a consistent encoding)
 with open("README.md", "r", encoding="utf-8") as fh:


### PR DESCRIPTION
fix: added python -m to handle pip command is not found error in Jupyter when install the package from github.

```bash
%pip install git+https://github.com/lyogavin/airllm.git#subdirectory=air_llm
```