### PR TITLE
Fix BetterTransformer import crash with newer optimum versions

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -15,7 +15,11 @@ from transformers.quantizers import AutoHfQuantizer, HfQuantizer
 
 from .profiler import LayeredProfiler
 
-from optimum.bettertransformer import BetterTransformer
+try:
+    from optimum.bettertransformer import BetterTransformer
+    bettertransformer_available = True
+except ImportError:
+    bettertransformer_available = False
 
 from .utils import clean_memory, load_layer, \
     find_or_create_local_splitted_path
@@ -185,14 +189,15 @@ class AirLLMBaseModel(GenerationMixin):
         self.model = None
 
         if self.get_use_better_transformer():
-            try:
-                with init_empty_weights():
-                    self.model = AutoModelForCausalLM.from_config(self.config, trust_remote_code=True)
-                    self.model = BetterTransformer.transform(self.model)  # enable flash attention
-            except ValueError as ve:
-                del self.model
-                clean_memory()
-                self.model = None
+            if bettertransformer_available:
+                try:
+                    with init_empty_weights():
+                        self.model = AutoModelForCausalLM.from_config(self.config, trust_remote_code=True)
+                        self.model = BetterTransformer.transform(self.model)  # enable flash attention
+                except (ValueError, Exception) as ve:
+                    del self.model
+                    clean_memory()
+                    self.model = None
 
             if self.model is None:
                 # try way 2.
@@ -205,7 +210,7 @@ class AirLLMBaseModel(GenerationMixin):
                         self.model = AutoModelForCausalLM.from_config(self.config, attn_implementation="sdpa", trust_remote_code=True)
                     print(f"attn imp: {type(self.model.model.layers[3].self_attn)}")
 
-                except TypeError as ve:
+                except (TypeError, Exception) as ve:
                     del self.model
                     clean_memory()
                     self.model = None


### PR DESCRIPTION
## Summary

- `from optimum.bettertransformer import BetterTransformer` crashes on import with newer optimum versions where the module was removed
- This blocks all new users from even doing `from airllm import AutoModel`
- Made the import conditional (try/except) so the existing SDPA fallback path actually works
- Also widened except clauses in `init_model()` to catch broader errors during model init

Fixes #243, fixes #240