### PR TITLE
docs: setup project-specific open source standards and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: Create a report to help us improve AirLLM inference
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what happened. Include the full stack trace if you received an error (like MetadataIncompleteBuffer).
+      placeholder: I tried to run inference on Model X with 4bit compression, but the process crashed with...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Give us the exact snippet of python code to run so we can reproduce it.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Crucial for debugging memory issues! What OS, GPU model, VRAM size, python version, and bitsandbytes version were you using?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature / Model Request
+description: Request support for a new LLM architecture or an optimization feature
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new idea for AirLLM! 
+        
+        **Note:** If you are specifically requesting support for a *new model architecture*, please also consider filling out the official request form: [Request Model Support](https://docs.google.com/forms/d/e/1FAIpQLSe0Io9ANMT964Zi-OQOq1TJmnvP-G3_ZgQDhP7SatN0IEdbOg/viewform?usp=sf_link)
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature or model
+      description: If requesting a new model, provide the Huggingface repository URI.
+      placeholder: Ex. Support inferencing for Llama 3.1 405B on 8GB...
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Why is this important?
+      description: Explain the motivation.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What Changed
+<!-- Describe the specific changes made in this PR (e.g. added support for Qwen2.5, localized memory leak) -->
+
+## Why This Change
+<!-- Explain the motivation and context for this change -->
+
+## Implementation Details
+<!-- If adding a new model, describe the AutoModel detection additions or specific loader optimizations -->
+
+## Testing Done
+- [ ] Tested on restricted VRAM (4GB / 8GB)
+- [ ] Confirmed generation logic via example scripts
+- [ ] No significant loss in inference accuracy detected
+- [ ] Works with compression (`4bit` / `8bit`) (if applicable)
+
+## Type of Change
+- [ ] `fix:` Bug fix
+- [ ] `feat:` New feature / New Model Supported
+- [ ] `refactor:` Code refactoring (optimization)
+- [ ] `docs:` Documentation improvements
+- [ ] `chore:` Maintenance/tooling
+
+## Quality Checklist
+- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
+- [ ] My code follows the Python style used in the project
+- [ ] No secrets, HF Tokens, or large files committed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to AirLLM
+
+First off, thank you for considering contributing to AirLLM! Because of community contributions, we're able to continuously optimize LLM inference on low-end commodity GPUs.
+
+## 1. Where do I go from here?
+
+If you've noticed a bug, want to request support for a new model (like QWen, Baichuan, Mistral, etc.), or have a feature request, please [open an issue](../../issues) on GitHub.
+
+## 2. Fork & create a branch
+
+If this is something you think you can fix or build, then [fork AirLLM](../../fork) and create a branch with a descriptive name.
+
+A good branch name:
+
+```sh
+# For adding model support
+git checkout -b feat/support-llama4
+
+# For a bug fix
+git checkout -b fix/safetensors-loading-error
+```
+
+## 3. Local Development
+
+1. Install the dependencies locally:
+   ```sh
+   pip install -r requirements.txt
+   ```
+2. We recommend testing your changes on constrained hardware (like a 4GB or 8GB VRAM GPU) since AirLLM's entire goal is memory optimization.
+3. If you integrate a new model, ensure it's evaluated against standard prompts to verify no major accuracy loss occurred during block-wise quantization/compression.
+
+## 4. Get the style right
+
+Your patch should follow the standard Python coding conventions used across the project. 
+- Format your code (consider using tools like `black` or `flake8` if enforced).
+- Do not check in large `.safetensors` or `.bin` model files. Always download them via Python scripts or point to `huggingface` handles.
+
+## 5. Make a Pull Request
+
+Make sure your fork is up-to-date with upstream before submitting your PR:
+
+```sh
+git remote add upstream https://github.com/lyogavin/airllm.git
+git checkout main
+git pull upstream main
+```
+
+Rebase or merge your feature branch:
+
+```sh
+git checkout feat/support-llama4
+git rebase main
+git push --set-upstream origin feat/support-llama4
+```
+
+Finally, go to GitHub and create a Pull Request on the main repository comparing against `lyogavin/airllm`.
+
+Thank you for contributing!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Please check the table below for the supported versions of AirLLM that currently receive security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of our project seriously. Given that AirLLM processes complex model files and involves heavy block-wise operations or API loading, vulnerabilities can arise.
+
+If you discover a security vulnerability in AirLLM, please **DO NOT** open a public issue.
+
+Instead, please report it privately to the maintainers to give us time to patch the issue before making it public.
+Use GitHub's private vulnerability reporting feature if enabled, or reach out to the core maintainers.
+
+Please provide a detailed summary of the vulnerability, including how to reproduce it and the potential impact (e.g. arbitrary code execution when unpacking safetensors).


### PR DESCRIPTION
## What Changed
- Added `.github/ISSUE_TEMPLATE` forms highly customized for AirLLM (forcing users to state their VRAM size and GPU specs).
- Linked the official Google Form in the feature request YAML if users want to request new models.
- Added a `CONTRIBUTING.md` outlining the local development flow and tests utilizing restricted VRAM.
- Set up a standard `CODE_OF_CONDUCT.md` and `SECURITY.md` policy.
- Added `dependabot.yml` targeting the pip ecosystem.

## Why This Change
To reduce the maintainer burden. Because AirLLM is heavily hardware-dependent, standard bug reports often lack crucial context. By strictly enforcing structured YAML issue templates, users will now automatically provide their VRAM, GPU, and bitsandbytes versions upfront.
