### PR TITLE
Fix AirLLMLlamaMlx torch.LongTensor input — coerce to mlx.array at generate() boundary

### DIFF
--- a/air_llm/airllm/airllm_llama_mlx.py
+++ b/air_llm/airllm/airllm_llama_mlx.py
@@ -18,6 +18,32 @@ from .utils import clean_memory, load_layer, \
     find_or_create_local_splitted_path
 
 
+def _coerce_to_mlx_array(x):
+    """Normalize the input passed to AirLLMLlamaMlx.generate() into an mlx.array.
+
+    Tokenizer callers naturally use ``return_tensors="pt"`` (torch) or
+    ``return_tensors="np"`` (numpy) — both are common in the HuggingFace
+    ecosystem. The downstream ``tok_embeddings`` call requires an ``mlx.array``
+    index; without coercion, a torch tensor raises
+    ``ValueError: Cannot index mlx array using the given type.`` and a
+    numpy array works only by accident through the array interface.
+
+    This helper accepts mlx arrays (passthrough), torch tensors,
+    numpy arrays, or python sequences and returns a fresh ``mlx.array``.
+    """
+    if isinstance(x, mx.array):
+        return x
+    if hasattr(x, "detach"):
+        # torch.Tensor — detach + cpu + numpy handles tensors that may
+        # be on an accelerator device or have grad attached.
+        return mx.array(x.detach().cpu().numpy())
+    if hasattr(x, "__array__"):
+        # numpy.ndarray or anything implementing the array interface.
+        return mx.array(x)
+    # list / tuple / scalar — direct construction.
+    return mx.array(x)
+
+
 
 @dataclass
 class ModelArgs:
@@ -250,6 +276,14 @@ class AirLLMLlamaMlx:
 
 
     def generate(self, x, temperature=0, max_new_tokens=None, **kwargs):
+        # Coerce the input to mlx.array before passing it down — the
+        # tok_embeddings call inside model_generate requires an mlx
+        # array index. Tokenizer callers typically pass torch tensors
+        # (``return_tensors="pt"``) or numpy arrays; without this
+        # coercion, torch tensors raise
+        # ``ValueError: Cannot index mlx array using the given type.``
+        x = _coerce_to_mlx_array(x)
+
         tokens = []
         for token in self.model_generate(x, temperature=temperature):
             tokens.append(token)

--- a/air_llm/tests/test_input_normalization.py
+++ b/air_llm/tests/test_input_normalization.py
@@ -1,0 +1,87 @@
+"""Regression test for the AirLLMLlamaMlx input-coercion fix.
+
+Before this fix, ``AirLLMLlamaMlx.generate(input_ids)`` raised
+
+    ValueError: Cannot index mlx array using the given type.
+
+whenever ``input_ids`` was a ``torch.LongTensor`` (the natural output
+of ``tokenizer(text, return_tensors="pt").input_ids``). The downstream
+``mlx.nn.Embedding`` call cannot index an mlx array using a torch
+tensor.
+
+The fix introduces ``_coerce_to_mlx_array`` and calls it at the
+``generate()`` entry point so callers don't need to know about
+``mlx.core``. This test exercises the helper on every input shape the
+generate boundary realistically receives.
+"""
+
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import torch
+
+from ..airllm.airllm_llama_mlx import _coerce_to_mlx_array
+
+
+class TestCoerceToMlxArray(unittest.TestCase):
+    """Direct tests on the helper."""
+
+    def test_mlx_array_is_passthrough(self):
+        x = mx.array([[1, 2, 3]])
+        out = _coerce_to_mlx_array(x)
+        self.assertIs(out, x)
+
+    def test_torch_long_tensor_is_converted(self):
+        # The exact shape that triggers the original bug:
+        # tokenizer(..., return_tensors="pt").input_ids is a 2D
+        # torch.LongTensor of shape (batch, seq_len).
+        x = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        out = _coerce_to_mlx_array(x)
+        self.assertIsInstance(out, mx.array)
+        self.assertEqual(out.shape, (1, 4))
+
+    def test_torch_grad_tensor_is_handled(self):
+        # input_ids don't normally have grad, but the helper should
+        # not crash if a caller passes a grad-attached tensor.
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        out = _coerce_to_mlx_array(x)
+        self.assertIsInstance(out, mx.array)
+
+    def test_numpy_array_is_converted(self):
+        x = np.array([[1, 2, 3]], dtype=np.int64)
+        out = _coerce_to_mlx_array(x)
+        self.assertIsInstance(out, mx.array)
+        self.assertEqual(out.shape, (1, 3))
+
+    def test_python_list_is_converted(self):
+        x = [[1, 2, 3]]
+        out = _coerce_to_mlx_array(x)
+        self.assertIsInstance(out, mx.array)
+        self.assertEqual(out.shape, (1, 3))
+
+
+class TestEmbeddingIntegration(unittest.TestCase):
+    """End-to-end regression: the original failure was in
+    ``self.tok_embeddings(x)`` inside model_generate. Verify the
+    coerced input flows through an mlx.nn.Embedding without raising.
+    """
+
+    def test_torch_tensor_through_embedding_after_coerce(self):
+        emb = nn.Embedding(100, 4)
+
+        # Confirm the original failure mode is real (sanity check —
+        # if this ever stops failing, something changed in mlx).
+        raw_torch = torch.tensor([[1, 2, 3]], dtype=torch.long)
+        with self.assertRaises((ValueError, TypeError)):
+            emb(raw_torch)
+
+        # The fix: coerce, then use.
+        coerced = _coerce_to_mlx_array(raw_torch)
+        out = emb(coerced)
+        self.assertEqual(out.shape, (1, 3, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Fixes `ValueError: Cannot index mlx array using the given type.` raised by `AirLLMLlamaMlx.generate()` when the input is a `torch.LongTensor` (the natural output of `tokenizer(text, return_tensors="pt").input_ids`).

Closes #280.

## Why this matters

On macOS, `AutoModel.from_pretrained(...)` routes every architecture (Qwen, Llama, Mistral, Mixtral, GLM, Baichuan, …) through `AirLLMLlamaMlx`. The natural HuggingFace caller pattern is:

```python
model = AutoModel.from_pretrained(name)
input_ids = model.tokenizer(text, return_tensors="pt").input_ids
model.generate(input_ids, max_new_tokens=N)
```

This pattern crashes today on every Apple Silicon install. The fix unblocks the entire MLX backend for every architecture.

## How

Adds `_coerce_to_mlx_array(x)` — a small helper that accepts mlx arrays (passthrough), torch tensors, numpy arrays, or python sequences and returns a fresh `mlx.array`. Called at the entry to `generate()` so callers don't need to know about `mlx.core`.

- **mlx.array** → returned as-is (zero overhead)
- **torch.Tensor** → `mx.array(x.detach().cpu().numpy())` (handles tensors on accelerators or with grad attached)
- **numpy.ndarray / array-like** → `mx.array(x)` (uses array interface)
- **list / tuple** → `mx.array(x)` (direct construction)

## Tests

New `air_llm/tests/test_input_normalization.py`:

- `TestCoerceToMlxArray` — direct unit tests on the helper for each input shape (5 cases)
- `TestEmbeddingIntegration` — end-to-end regression: confirms the original bug is real (the raw torch tensor still raises through `mlx.nn.Embedding`) and that the coerced input flows through cleanly

Run:

```bash
python -m unittest air_llm.tests.test_input_normalization -v
# → 6 tests, OK

# And the existing test still passes:
python -m unittest air_llm.tests.test_automodel -v
# → 1 test, OK
```

## Diff size

One source file changed, +34 lines / -0 lines. One new test file. No behavior change for callers already passing `mlx.array`.

## Hardware tested

Apple M-series (M5 Pro). The fix is platform-agnostic at the code level — only the MLX runtime is Apple Silicon specific.