### PR TITLE
Add Qwen3.6/Qwen3.5 support for newer Transformers versions

### DIFF
--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -13,6 +13,7 @@ else:
     from .airllm_chatglm import AirLLMChatGLM
     from .airllm_qwen import AirLLMQWen
     from .airllm_qwen2 import AirLLMQWen2
+    from .airllm_qwen3_5 import AirLLMQWen3_5
     from .airllm_baichuan import AirLLMBaichuan
     from .airllm_internlm import AirLLMInternLM
     from .airllm_mistral import AirLLMMistral

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -15,7 +15,12 @@ from transformers.quantizers import AutoHfQuantizer, HfQuantizer
 
 from .profiler import LayeredProfiler
 
-from optimum.bettertransformer import BetterTransformer
+try:
+    from optimum.bettertransformer import BetterTransformer
+except Exception:
+    # Recent optimum/transformers combinations can raise at import time because
+    # BetterTransformer is deprecated. AirLLM can still use the SDPA/direct path.
+    BetterTransformer = None
 
 from .utils import clean_memory, load_layer, \
     find_or_create_local_splitted_path
@@ -178,6 +183,9 @@ class AirLLMBaseModel(GenerationMixin):
     def get_use_better_transformer(self):
         return True
 
+    def create_model_from_config(self, **kwargs):
+        return AutoModelForCausalLM.from_config(self.config, trust_remote_code=True, **kwargs)
+
     def init_model(self):
 
         # try way 1 better transformers...
@@ -185,14 +193,15 @@ class AirLLMBaseModel(GenerationMixin):
         self.model = None
 
         if self.get_use_better_transformer():
-            try:
-                with init_empty_weights():
-                    self.model = AutoModelForCausalLM.from_config(self.config, trust_remote_code=True)
-                    self.model = BetterTransformer.transform(self.model)  # enable flash attention
-            except ValueError as ve:
-                del self.model
-                clean_memory()
-                self.model = None
+            if BetterTransformer is not None:
+                try:
+                    with init_empty_weights():
+                        self.model = self.create_model_from_config()
+                        self.model = BetterTransformer.transform(self.model)  # enable flash attention
+                except (ValueError, RuntimeError):
+                    del self.model
+                    clean_memory()
+                    self.model = None
 
             if self.model is None:
                 # try way 2.
@@ -202,7 +211,7 @@ class AirLLMBaseModel(GenerationMixin):
                     self.config.attn_implementation = "sdpa"
 
                     with init_empty_weights():
-                        self.model = AutoModelForCausalLM.from_config(self.config, attn_implementation="sdpa", trust_remote_code=True)
+                        self.model = self.create_model_from_config(attn_implementation="sdpa")
                     print(f"attn imp: {type(self.model.model.layers[3].self_attn)}")
 
                 except TypeError as ve:
@@ -214,7 +223,7 @@ class AirLLMBaseModel(GenerationMixin):
         if self.model is None:
             print(f"either BetterTransformer or attn_implementation='sdpa' is available, creating model directly")
             with init_empty_weights():
-                self.model = AutoModelForCausalLM.from_config(self.config, trust_remote_code=True)
+                self.model = self.create_model_from_config()
 
         quantization_config = getattr(self.config, "quantization_config", None)
 
@@ -300,6 +309,24 @@ class AirLLMBaseModel(GenerationMixin):
         return state_dict
 
     def move_layer_to_device(self, state_dict):
+        use_legacy_quantizer_api = (
+            self.hf_quantizer is not None
+            and hasattr(self.hf_quantizer, "check_quantized_param")
+            and hasattr(self.hf_quantizer, "create_quantized_param")
+        )
+
+        if self.hf_quantizer is not None and not use_legacy_quantizer_api:
+            moved_layers = []
+            for param_name, param in state_dict.items():
+                set_module_tensor_to_device(
+                    self.model,
+                    param_name,
+                    self.running_device,
+                    value=param,
+                )
+                moved_layers.append(param_name)
+            return moved_layers
+
         layers = []
         for param_name, param in state_dict.items():
             if self.hf_quantizer is None:
@@ -566,7 +593,8 @@ class AirLLMBaseModel(GenerationMixin):
                                 kwargs = {**kwargs, **pos_embed_args, **attention_mask_args, **position_ids_args}
 
 
-                                new_seq = layer(seq, **kwargs)[0]
+                                layer_out = layer(seq, **kwargs)
+                                new_seq = layer_out[0] if isinstance(layer_out, tuple) else layer_out
                             else:
 
                                 kwargs = {'use_cache': True,

--- a/air_llm/airllm/airllm_qwen3_5.py
+++ b/air_llm/airllm/airllm_qwen3_5.py
@@ -1,0 +1,42 @@
+import torch
+
+from .airllm_base import AirLLMBaseModel
+
+
+class AirLLMQWen3_5(AirLLMBaseModel):
+    def __init__(self, *args, **kwargs):
+        super(AirLLMQWen3_5, self).__init__(*args, **kwargs)
+
+    def create_model_from_config(self, **kwargs):
+        from transformers import AutoModelForImageTextToText
+
+        return AutoModelForImageTextToText.from_config(self.config, trust_remote_code=True, **kwargs)
+
+    def get_use_better_transformer(self):
+        return False
+
+    def set_layer_names_dict(self):
+        self.layer_names_dict = {
+            'embed': 'model.language_model.embed_tokens',
+            'layer_prefix': 'model.language_model.layers',
+            'norm': 'model.language_model.norm',
+            'lm_head': 'lm_head',
+        }
+
+    def get_pos_emb_args(self, len_p, len_s):
+        position_ids = torch.arange(
+            len_p,
+            len_p + len_s,
+            dtype=torch.long,
+            device=self.running_device,
+        )[None, :]
+        hidden_size = getattr(self.config.text_config, "hidden_size", 1)
+        x = torch.empty(
+            1,
+            len_s,
+            hidden_size,
+            dtype=self.running_dtype,
+            device=self.running_device,
+        )
+        position_embeddings = self.model.model.language_model.rotary_emb(x, position_ids)
+        return {'position_embeddings': position_embeddings}

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -24,24 +24,35 @@ class AutoModel:
         else:
             config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
 
-        if "Qwen2ForCausalLM" in config.architectures[0]:
+        architecture = config.architectures[0] if getattr(config, "architectures", None) else ""
+        model_type = getattr(config, "model_type", "")
+        text_config = getattr(config, "text_config", None)
+        text_model_type = getattr(text_config, "model_type", "")
+
+        if (
+            "Qwen3_5" in architecture
+            or model_type == "qwen3_5"
+            or text_model_type == "qwen3_5_text"
+        ):
+            return "airllm", "AirLLMQWen3_5"
+        elif "Qwen2ForCausalLM" in architecture:
             return "airllm", "AirLLMQWen2"
-        elif "QWen" in config.architectures[0]:
+        elif "QWen" in architecture:
             return "airllm", "AirLLMQWen"
-        elif "Baichuan" in config.architectures[0]:
+        elif "Baichuan" in architecture:
             return "airllm", "AirLLMBaichuan"
-        elif "ChatGLM" in config.architectures[0]:
+        elif "ChatGLM" in architecture:
             return "airllm", "AirLLMChatGLM"
-        elif "InternLM" in config.architectures[0]:
+        elif "InternLM" in architecture:
             return "airllm", "AirLLMInternLM"
-        elif "Mistral" in config.architectures[0]:
+        elif "Mistral" in architecture:
             return "airllm", "AirLLMMistral"
-        elif "Mixtral" in config.architectures[0]:
+        elif "Mixtral" in architecture:
             return "airllm", "AirLLMMixtral"
-        elif "Llama" in config.architectures[0]:
+        elif "Llama" in architecture:
             return "airllm", "AirLLMLlama2"
         else:
-            print(f"unknown artichitecture: {config.architectures[0]}, try to use Llama2...")
+            print(f"unknown artichitecture: {architecture}, try to use Llama2...")
             return "airllm", "AirLLMLlama2"
 
     @classmethod

--- a/air_llm/tests/test_automodel.py
+++ b/air_llm/tests/test_automodel.py
@@ -1,10 +1,19 @@
 import sys
 import unittest
+from unittest.mock import patch
 
 #sys.path.insert(0, '../airllm')
 
+from ..airllm import auto_model as auto_model_module
 from ..airllm.auto_model import AutoModel
 
+
+class _Config:
+    def __init__(self, architectures, model_type="", text_model_type=""):
+        self.architectures = architectures
+        self.model_type = model_type
+        if text_model_type:
+            self.text_config = _Config([], model_type=text_model_type)
 
 
 class TestAutoModel(unittest.TestCase):
@@ -29,3 +38,15 @@ class TestAutoModel(unittest.TestCase):
             module, cls = AutoModel.get_module_class(k)
             self.assertEqual(cls, v, f"expecting {v}")
 
+    def test_auto_model_should_detect_qwen3_5_architecture(self):
+        qwen3_5_configs = [
+            _Config(["Qwen3_5ForConditionalGeneration"], "qwen3_5"),
+            _Config([], "qwen3_5"),
+            _Config([], text_model_type="qwen3_5_text"),
+        ]
+
+        for config in qwen3_5_configs:
+            with patch.object(auto_model_module.AutoConfig, "from_pretrained", return_value=config):
+                module, cls = AutoModel.get_module_class("Qwen/Qwen3.6-27B-FP8")
+                self.assertEqual(module, "airllm")
+                self.assertEqual(cls, "AirLLMQWen3_5")


### PR DESCRIPTION
This adds initial support for Qwen3.6 models in AirLLM.

Qwen3.6 checkpoints are exposed by Transformers under the `qwen3_5` / `Qwen3_5ForConditionalGeneration` architecture name, so AirLLM was previously falling back to the Llama adapter. This PR adds a dedicated Qwen3.6/Qwen3.5 adapter and updates AutoModel detection so those checkpoints are routed correctly.

It also makes the BetterTransformer import optional, since newer Optimum/Transformers versions may no longer expose it, and adds compatibility for newer Hugging Face quantizer APIs.

Tested with:

- `python -m compileall`
- `python -m unittest air_llm.tests.test_automodel`
- local Qwen3.6 config routing smoke test
