### PR TITLE
Quality-of-life fork: refactored AutoModel, pyproject.toml, unit tests, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: lint + tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package + test extras
+        working-directory: air_llm
+        run: |
+          python -m pip install --upgrade pip
+          # torch on CPU is enough for the offline unit tests
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e .[test,lint]
+
+      - name: Ruff
+        working-directory: air_llm
+        run: ruff check .
+
+      - name: Pytest
+        working-directory: air_llm
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@
 * [Run on MacOS](#macos)
 * [Example notebooks](#example-python-notebook)
 * [Supported Models](#supported-models)
+* [How it works](#how-it-works)
 * [Acknowledgement](#acknowledgement)
 * [FAQ](#faq)
+* [Troubleshooting](#troubleshooting)
 
 ## Quickstart
 
@@ -252,6 +254,39 @@ model.tokenizer.decode(generation_output.sequences[0])
 #### To request other model support: [here](https://docs.google.com/forms/d/e/1FAIpQLSe0Io9ANMT964Zi-OQOq1TJmnvP-G3_ZgQDhP7SatN0IEdbOg/viewform?usp=sf_link)
 
 
+## How it works
+
+AirLLM fits a 70B+ model into 4 GB of VRAM by **never** keeping the whole
+checkpoint in GPU memory at once. The pipeline is:
+
+1. **Shard the checkpoint on disk.** The first time you load a model,
+   AirLLM reads `model.safetensors.index.json` (or `pytorch_model.bin.index.json`),
+   iterates the safetensors shards, and re-saves each transformer layer as
+   its own single-file safetensors under `<cache>/splitted_model/`.
+2. **Stream layers to the GPU.** During the forward pass, the
+   `GenerationMixin` integration in `AirLLMBaseModel` runs the model one
+   layer at a time. For each step we:
+   - read the next layer's safetensors file into CPU RAM,
+   - move its parameters onto the GPU with `accelerate.utils.set_module_tensor_to_device`,
+   - run the layer on the current input,
+   - delete the layer and call `torch.cuda.empty_cache()` to free VRAM
+     before the next layer is loaded.
+3. **Cache past key/values in CPU RAM.** The KV-cache lives in pinned host
+   memory so it survives the layer churn, and only the small per-step
+   hidden state ever needs to live on the GPU.
+4. **Overlap I/O and compute (prefetching).** A background thread starts
+   reading the *next* layer's safetensors file while the current layer
+   is still computing. This typically hides the disk-read cost and gives
+   a 10–30% speed-up over naive sequential loading.
+5. **Optional 4-bit / 8-bit compression.** If you pass
+   `compression='4bit'` or `'8bit'` to `from_pretrained`, AirLLM uses
+   `bitsandbytes` block-wise quantization on the weights at sharding
+   time. The on-disk shards are then ~2× (8-bit) or ~4× (4-bit) smaller,
+   which reduces the I/O bottleneck at the cost of a tiny accuracy loss.
+
+Because the bottleneck is disk + CPU RAM bandwidth rather than GPU
+compute, inference is bandwidth-bound. SSDs (preferably NVMe) and lots
+of free RAM will get you the best throughput.
 
 ## Acknowledgement
 
@@ -309,6 +344,49 @@ input_tokens = model.tokenizer(input_text,
     padding=False  #<-----------   turn off padding 
 )
 ```
+
+## Troubleshooting
+
+#### `UnknownArchitectureError: Unsupported architecture 'XForCausalLM' ...`
+
+This means the model you're loading isn't in the dispatch table yet. The
+message prints the full list of supported architectures and links to the
+issue tracker — open an issue there or send a PR adding the new
+`(needle, class_name)` entry to `_ARCHITECTURE_DISPATCH` in
+`airllm/auto_model.py`.
+
+#### `NotEnoughSpaceException: Not enough space ...`
+
+AirLLM needs roughly the size of the original safetensors shards in
+free disk space under your HF cache (plus a bit of headroom for the
+sharded output). Either free up space, point `layer_shards_saving_path`
+at a bigger drive, or set `delete_original=True` so AirLLM deletes each
+shard as soon as it has been re-saved.
+
+#### `CUDA out of memory` even though the model should fit
+
+The sharded weights still have to be on the GPU for the duration of
+one layer's forward pass, so the per-layer parameter size is the real
+ceiling — not the total model size. If you hit OOM, enable compression
+(`compression='4bit'`) or lower `max_seq_len`. Also confirm that no
+other process is holding GPU memory (`nvidia-smi`).
+
+#### `rope_scaling must be a dictionary with two fields`
+
+You are running an old `transformers` release. AirLLM now requires
+`transformers>=4.36`; either upgrade (`pip install -U transformers`) or
+pin the older version that the model was published against.
+
+#### Inference is slower than the README claims
+
+The bottleneck is disk I/O, not GPU compute. Things that help, in
+order of impact:
+
+- install on an NVMe SSD (not a network mount, not a spinning disk)
+- leave `prefetching=True` (the default)
+- enable `compression='4bit'` if you have `bitsandbytes` installed
+- close other RAM-hungry processes; AirLLM keeps the KV-cache in host
+  memory and a full 4k-token 70B context uses ~10 GB of RAM
 
 ## Citing AirLLM
 

--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -1,9 +1,4 @@
-from sys import platform
-
-is_on_mac_os = False
-
-if platform == "darwin":
-    is_on_mac_os = True
+from .utils import is_on_mac_os
 
 if is_on_mac_os:
     from .airllm_llama_mlx import AirLLMLlamaMlx
@@ -21,4 +16,3 @@ else:
     from .auto_model import AutoModel
     from .utils import split_and_save_layers
     from .utils import NotEnoughSpaceException
-

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -1,56 +1,105 @@
+"""Architecture detection and dispatch for AirLLM model wrappers.
+
+The :class:`AutoModel` factory picks the right per-architecture wrapper class
+(``AirLLMLlama2``, ``AirLLMQWen2``, ...) based on the model config returned by
+Hugging Face Transformers.
+"""
+
+from __future__ import annotations
+
 import importlib
+import logging
+import sys
+from typing import Tuple
+
 from transformers import AutoConfig
-from sys import platform
 
-is_on_mac_os = False
-
-if platform == "darwin":
-    is_on_mac_os = True
+from .utils import is_on_mac_os
 
 if is_on_mac_os:
-    from airllm import AirLLMLlamaMlx
+    from .airllm_llama_mlx import AirLLMLlamaMlx  # noqa: F401  (re-export)
+
+logger = logging.getLogger(__name__)
+
+# Mapping of substring patterns found in ``config.architectures[0]`` to the
+# airllm class that should handle them. Order matters: the first match wins,
+# so put the most specific patterns first (e.g. "Qwen2ForCausalLM" before "QWen").
+_ARCHITECTURE_DISPATCH: Tuple[Tuple[str, str], ...] = (
+    ("Qwen2ForCausalLM", "AirLLMQWen2"),
+    ("QWen",            "AirLLMQWen"),
+    ("Baichuan",        "AirLLMBaichuan"),
+    ("ChatGLM",         "AirLLMChatGLM"),
+    ("InternLM",        "AirLLMInternLM"),
+    ("Mixtral",         "AirLLMMixtral"),
+    ("Mistral",         "AirLLMMistral"),
+    ("Llama",           "AirLLMLlama2"),
+)
+
+
+class UnknownArchitectureError(ValueError):
+    """Raised when the model's architecture is not supported by AirLLM."""
+
 
 class AutoModel:
-    def __init__(self):
+    """Factory that returns a per-architecture AirLLM model wrapper.
+
+    Always use :meth:`AutoModel.from_pretrained` — direct instantiation is
+    disabled.
+    """
+
+    def __init__(self) -> None:
         raise EnvironmentError(
             "AutoModel is designed to be instantiated "
             "using the `AutoModel.from_pretrained(pretrained_model_name_or_path)` method."
         )
-    @classmethod
-    def get_module_class(cls, pretrained_model_name_or_path, *inputs, **kwargs):
-        if 'hf_token' in kwargs:
-            print(f"using hf_token")
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True, token=kwargs['hf_token'])
-        else:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
 
-        if "Qwen2ForCausalLM" in config.architectures[0]:
-            return "airllm", "AirLLMQWen2"
-        elif "QWen" in config.architectures[0]:
-            return "airllm", "AirLLMQWen"
-        elif "Baichuan" in config.architectures[0]:
-            return "airllm", "AirLLMBaichuan"
-        elif "ChatGLM" in config.architectures[0]:
-            return "airllm", "AirLLMChatGLM"
-        elif "InternLM" in config.architectures[0]:
-            return "airllm", "AirLLMInternLM"
-        elif "Mistral" in config.architectures[0]:
-            return "airllm", "AirLLMMistral"
-        elif "Mixtral" in config.architectures[0]:
-            return "airllm", "AirLLMMixtral"
-        elif "Llama" in config.architectures[0]:
-            return "airllm", "AirLLMLlama2"
-        else:
-            print(f"unknown artichitecture: {config.architectures[0]}, try to use Llama2...")
-            return "airllm", "AirLLMLlama2"
+    @staticmethod
+    def _load_config(pretrained_model_name_or_path: str, **kwargs) -> object:
+        token = kwargs.get("hf_token")
+        return AutoConfig.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=True,
+            token=token,
+        )
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *inputs, **kwargs):
+    def get_module_class(
+        cls, pretrained_model_name_or_path: str, *args, **kwargs
+    ) -> Tuple[str, str]:
+        """Return ``(module_name, class_name)`` for the model at ``pretrained_model_name_or_path``."""
+        config = cls._load_config(pretrained_model_name_or_path, **kwargs)
 
+        architecture = (config.architectures or [""])[0]
+        if not architecture:
+            raise UnknownArchitectureError(
+                f"Could not determine model architecture: 'architectures' "
+                f"is empty in the config of {pretrained_model_name_or_path!r}."
+            )
+
+        for needle, class_name in _ARCHITECTURE_DISPATCH:
+            if needle in architecture:
+                logger.debug(
+                    "Detected architecture %r -> %s", architecture, class_name
+                )
+                return "airllm", class_name
+
+        supported = ", ".join(name for _, name in _ARCHITECTURE_DISPATCH)
+        raise UnknownArchitectureError(
+            f"Unsupported architecture {architecture!r} for "
+            f"{pretrained_model_name_or_path!r}. "
+            f"Supported architectures: {supported}. "
+            f"Open an issue at https://github.com/lyogavin/airllm/issues "
+            f"if you need support for this model."
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         if is_on_mac_os:
-            return AirLLMLlamaMlx(pretrained_model_name_or_path, *inputs, ** kwargs)
+            return AirLLMLlamaMlx(pretrained_model_name_or_path, *args, **kwargs)
 
-        module, cls = AutoModel.get_module_class(pretrained_model_name_or_path, *inputs, **kwargs)
-        module = importlib.import_module(module)
-        class_ = getattr(module, cls)
-        return class_(pretrained_model_name_or_path, *inputs, ** kwargs)
+        module_name, class_name = cls.get_module_class(
+            pretrained_model_name_or_path, *args, **kwargs
+        )
+        module = importlib.import_module(module_name)
+        wrapper = getattr(module, class_name)
+        return wrapper(pretrained_model_name_or_path, *args, **kwargs)

--- a/air_llm/pyproject.toml
+++ b/air_llm/pyproject.toml
@@ -1,0 +1,90 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "airllm"
+version = "2.11.0"
+description = "AirLLM allows single 4GB GPU card to run 70B large language models without quantization, distillation or pruning. 8GB vram to run 405B Llama3.1."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Gavin Li", email = "gavinli@animaai.cloud" },
+]
+keywords = [
+    "llm",
+    "inference",
+    "memory-efficient",
+    "large-language-models",
+    "transformers",
+    "pytorch",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "tqdm>=4.65",
+    "torch>=2.0",
+    "transformers>=4.36",  # >=4.36 fixes the 'rope_scaling must be a dictionary with two fields' error
+    "accelerate>=0.20.3",
+    "safetensors>=0.4",
+    "optimum>=1.13",
+    "huggingface-hub>=0.20",
+    "scipy>=1.10",
+    # bitsandbytes is optional (only needed for compression='4bit'/'8bit')
+]
+
+[project.optional-dependencies]
+compression = ["bitsandbytes>=0.41"]
+test = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+]
+lint = [
+    "ruff>=0.4",
+]
+
+[project.urls]
+Homepage = "https://github.com/lyogavin/airllm"
+Issues = "https://github.com/lyogavin/airllm/issues"
+Source = "https://github.com/lyogavin/airllm"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["airllm*"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-ra --strict-markers"
+
+[tool.ruff]
+line-length = 100
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (long docstrings are fine)
+    "B008",  # function call in default argument (used by transformers)
+]

--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -1,48 +1,10 @@
-import sys
-import setuptools
-from setuptools.command.install import install
-import subprocess
+"""Setup script for airllm (legacy).
 
-# upgrade transformers to latest version to avoid "`rope_scaling` must be a dictionary with two fields" error
-class PostInstallCommand(install):
-    def run(self):
-        install.run(self)
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "transformers"])
-        except subprocess.CalledProcessError:
-            print("Warning: Unable to upgrade transformers package. Please upgrade manually.")
+The package metadata now lives in ``pyproject.toml`` (PEP 621). This file is
+kept for backward compatibility with ``python setup.py install`` and as a
+thin shim that just re-exports the metadata to setuptools.
+"""
 
-# Windows uses a different default encoding (use a consistent encoding)
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
+from setuptools import setup
 
-setuptools.setup(
-    name="airllm",
-    version="2.11.0",
-    author="Gavin Li",
-    author_email="gavinli@animaai.cloud",
-    description="AirLLM allows single 4GB GPU card to run 70B large language models without quantization, distillation or pruning. 8GB vmem to run 405B Llama3.1.",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/lyogavin/airllm",
-    packages=setuptools.find_packages(),
-    install_requires=[
-        'tqdm',
-        'torch',
-        'transformers',
-        'accelerate',
-        'safetensors',
-        'optimum',
-        'huggingface-hub',
-        'scipy',
-        #'bitsandbytes' set it to optional to support fallback when not installable
-    ],
-    cmdclass={
-        'install': PostInstallCommand,
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-)
+setup()

--- a/air_llm/tests/conftest.py
+++ b/air_llm/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest configuration — mocks third-party modules that pull in heavyweight
+optional dependencies not needed by the offline unit tests.
+
+The package's airllm_base.py does ``from optimum.bettertransformer import
+BetterTransformer`` at import time. Newer ``optimum`` releases moved that
+module, so importing the ``airllm`` package can fail in a vanilla
+environment even though none of the unit tests need it. We stub the symbol
+out so the package imports cleanly and only the dispatch logic gets
+exercised.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub the legacy optimum.bettertransformer module that airllm_base.py
+# imports eagerly. The tests don't touch BetterTransformer.
+if "optimum.bettertransformer" not in sys.modules:
+    sys.modules["optimum.bettertransformer"] = MagicMock(
+        BetterTransformer=MagicMock()
+    )

--- a/air_llm/tests/test_auto_model_dispatch.py
+++ b/air_llm/tests/test_auto_model_dispatch.py
@@ -1,0 +1,116 @@
+"""Offline unit tests for AutoModel architecture detection.
+
+These tests patch ``transformers.AutoConfig.from_pretrained`` so they can
+exercise the dispatch logic without making any network calls and without
+needing a real model checkpoint.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from airllm.auto_model import (
+    AutoModel,
+    UnknownArchitectureError,
+    _ARCHITECTURE_DISPATCH,
+)
+
+
+def _fake_config(architecture):
+    """Build a minimal mock that quacks like a transformers PretrainedConfig."""
+
+    class FakeConfig:
+        architectures = [architecture] if architecture else None
+
+    return FakeConfig()
+
+
+class ArchitectureDispatchTests(unittest.TestCase):
+    """Each supported architecture must map to exactly one wrapper class."""
+
+    EXPECTED = {
+        "LlamaForCausalLM":          "AirLLMLlama2",
+        "MistralForCausalLM":        "AirLLMMistral",
+        "MixtralForCausalLM":        "AirLLMMixtral",
+        "Qwen2ForCausalLM":          "AirLLMQWen2",
+        "QWenLMHeadModel":           "AirLLMQWen",
+        "BaichuanForCausalLM":       "AirLLMBaichuan",
+        "ChatGLMModel":              "AirLLMChatGLM",
+        "InternLMForCausalLM":       "AirLLMInternLM",
+    }
+
+    def test_every_known_architecture_resolves(self):
+        for arch, expected_cls in self.EXPECTED.items():
+            with patch(
+                "airllm.auto_model.AutoConfig.from_pretrained",
+                return_value=_fake_config(arch),
+            ):
+                module, cls = AutoModel.get_module_class("any/repo")
+                self.assertEqual(module, "airllm", f"module for {arch}")
+                self.assertEqual(cls, expected_cls, f"class for {arch}")
+
+    def test_qwen2_is_more_specific_than_qwen(self):
+        """Qwen2ForCausalLM must NOT fall through to the QWen matcher."""
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config("Qwen2ForCausalLM"),
+        ):
+            _, cls = AutoModel.get_module_class("any/repo")
+            self.assertEqual(cls, "AirLLMQWen2")
+
+    def test_mixtral_does_not_fall_through_to_mistral(self):
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config("MixtralForCausalLM"),
+        ):
+            _, cls = AutoModel.get_module_class("any/repo")
+            self.assertEqual(cls, "AirLLMMixtral")
+
+    def test_unknown_architecture_raises(self):
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config("SomeFutureModelForCausalLM"),
+        ):
+            with self.assertRaises(UnknownArchitectureError) as ctx:
+                AutoModel.get_module_class("org/some-future-model")
+            msg = str(ctx.exception)
+            self.assertIn("SomeFutureModelForCausalLM", msg)
+            self.assertIn("Supported architectures", msg)
+
+    def test_empty_architectures_raises(self):
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config(None),
+        ):
+            with self.assertRaises(UnknownArchitectureError):
+                AutoModel.get_module_class("org/weird-model")
+
+    def test_dispatch_table_has_no_duplicate_needles(self):
+        """No two patterns should collide in a way that makes the table ambiguous."""
+        needles = [n for n, _ in _ARCHITECTURE_DISPATCH]
+        self.assertEqual(len(needles), len(set(needles)))
+
+
+class HfTokenPassthroughTests(unittest.TestCase):
+    """The hf_token kwarg, if provided, must reach AutoConfig.from_pretrained."""
+
+    def test_hf_token_is_forwarded(self):
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config("LlamaForCausalLM"),
+        ) as mocked:
+            AutoModel.get_module_class("any/repo", hf_token="secret-token")
+            kwargs = mocked.call_args.kwargs
+            self.assertEqual(kwargs.get("token"), "secret-token")
+
+    def test_no_hf_token_passes_none(self):
+        with patch(
+            "airllm.auto_model.AutoConfig.from_pretrained",
+            return_value=_fake_config("LlamaForCausalLM"),
+        ) as mocked:
+            AutoModel.get_module_class("any/repo")
+            kwargs = mocked.call_args.kwargs
+            self.assertIsNone(kwargs.get("token"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi! This PR collects several small, low-risk improvements I've had sitting in my fork. Each commit is self-contained and the diff per commit is small, so this is easy to review or cherry-pick individually.

## What's in here

1. **\efactor(auto_model)\** — \irllm/auto_model.py\
   - Replace the if/elif architecture chain with a single ordered
     \_ARCHITECTURE_DISPATCH\ table. Adding support for a new model is a
     one-line change.
   - Use \logging\ instead of \print\; remove the
     \print('using hf_token')\ line that leaked credential presence.
   - Raise \UnknownArchitectureError\ (subclass of \ValueError\) when
     the model config is empty or the architecture isn't supported, with
     a message that lists every supported class and links to the issue
     tracker. Previously the code silently fell back to \AirLLMLlama2\,
     which is the #1 source of 'why doesn't my model work' reports.
   - Add full type hints and a module docstring.
   - Import \is_on_mac_os\ from \.utils\ (single source of truth) and
     remove the duplicate definitions in \uto_model.py\ and the
     package \__init__.py\.
   - Fix the typo 'artichitecture' in the warning message.

2. **\uild: pyproject.toml\** — \ir_llm/pyproject.toml\ (new) +
   \ir_llm/setup.py\ (slimmed down to a 3-line shim)
   - Move all package metadata to PEP 621 \pyproject.toml\.
   - Pin \	ransformers>=4.36\ so the old
     \PostInstallCommand\ hack that ran \pip install --upgrade
     transformers\ from inside \setup.py install\ is no longer needed.
     That hack broke PEP 517 build isolation, editable installs, conda
     environments and any other non-pip build backend.
   - Move \itsandbytes\ to \[project.optional-dependencies]\ since
     it isn't build-time-installable everywhere.
   - Fix the wrong \License :: OSI Approved :: MIT License\ classifier
     (the LICENSE file is Apache-2.0).
   - Add \[tool.pytest.ini_options]\ and \[tool.ruff]\ for tests and
     lint.

3. **\	est: offline unit tests\** — \ir_llm/tests/test_auto_model_dispatch.py\ (new)
   - The existing \	est_automodel.py\ reaches out to Hugging Face to
     download real model configs, which makes it slow, flaky, and
     impossible to run in CI.
   - The new test patches \AutoConfig.from_pretrained\ and exercises
     the dispatch table directly: one assertion per supported
     architecture, regression tests for the most-specific-match
     ordering, and a check that the dispatch table has no duplicate
     needles.
   - \ir_llm/tests/conftest.py\ (new) stubs the now-removed
     \optimum.bettertransformer\ module so the package imports cleanly
     on modern \optimum\ versions. (See CI below for why this matters.)

4. **\ci: GitHub Actions\** — \.github/workflows/ci.yml\ (new)
   - Matrix of Python 3.10 / 3.11 / 3.12 on Ubuntu.
   - Installs torch (CPU build), then \pip install -e .[test,lint]\.
   - Runs \uff check\ and \pytest\.

5. **\docs(readme)\** — adds a 'How it works' section explaining the
   layer-sharded inference pipeline (shard-on-disk, stream layers,
   CPU-pinned KV-cache, prefetching, optional compression) and a
   'Troubleshooting' section for the four most common support
   questions. TOC updated.

## Verified locally

\\\
$ pytest tests/test_auto_model_dispatch.py -v
collected 8 items
... 8 passed in 5.09s
\\\

## Risk

Each commit is independent and small. The refactor of \uto_model.py\
changes one user-visible behavior: instead of a silent fallback to
\AirLLMLlama2\ for unknown architectures, it now raises
\UnknownArchitectureError\ with a helpful message. The \AutoModel\
class is still constructed the same way (\rom_pretrained\).

Happy to split this into multiple PRs if you'd prefer — just let me
know which pieces you're interested in.