### PR TITLE
Fix remove_real_and_linked_file double-deleting normal files

### DIFF
--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -176,12 +176,17 @@ def compress_layer_state_dict(layer_state_dict, compression=None):
     return compressed_layer_state_dict if compressed_layer_state_dict is not None else layer_state_dict
 
 def remove_real_and_linked_file(to_delete):
-    if (os.path.realpath(to_delete) != to_delete):
-        targetpath = os.path.realpath(to_delete)
+    # Only resolve+remove a link target when to_delete is actually a symlink (e.g. a HF cache
+    # snapshot file pointing at a blob). Comparing realpath(to_delete) != to_delete as strings
+    # also trips for perfectly normal files whose path just isn't already absolute/normalized
+    # (any relative path, or an absolute path with redundant components), which set targetpath
+    # to the same file under its resolved name and made the second os.remove() try to delete a
+    # file that the first call had already removed.
+    targetpath = os.path.realpath(to_delete) if os.path.islink(to_delete) else None
 
     os.remove(to_delete)
-    if (targetpath):
-         os.remove(targetpath)
+    if targetpath:
+        os.remove(targetpath)
 
 
 

--- a/air_llm/tests/test_remove_real_and_linked_file.py
+++ b/air_llm/tests/test_remove_real_and_linked_file.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+import unittest
+
+from airllm.utils import remove_real_and_linked_file
+
+
+class TestRemoveRealAndLinkedFile(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_removes_normal_absolute_file_once(self):
+        path = os.path.join(self.tmpdir.name, 'shard.bin')
+        with open(path, 'w') as f:
+            f.write('data')
+
+        remove_real_and_linked_file(path)
+
+        self.assertFalse(os.path.exists(path))
+
+    def test_removes_normal_relative_file_without_crash(self):
+        # Relative paths previously crashed: os.path.realpath() always returns an absolute
+        # path, so the old string comparison treated any relative path as "linked" and tried
+        # to remove the same underlying file twice.
+        path = os.path.join(self.tmpdir.name, 'shard_rel.bin')
+        with open(path, 'w') as f:
+            f.write('data')
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(self.tmpdir.name)
+            remove_real_and_linked_file('shard_rel.bin')
+        finally:
+            os.chdir(cwd)
+
+        self.assertFalse(os.path.exists(path))
+
+    def test_removes_symlink_and_its_target(self):
+        target = os.path.join(self.tmpdir.name, 'blob.bin')
+        link = os.path.join(self.tmpdir.name, 'snapshot_link.bin')
+        with open(target, 'w') as f:
+            f.write('data')
+        os.symlink(target, link)
+
+        remove_real_and_linked_file(link)
+
+        self.assertFalse(os.path.exists(link))
+        self.assertFalse(os.path.exists(target))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Bug

`remove_real_and_linked_file()` decided whether `to_delete` was a linked file by comparing `os.path.realpath(to_delete)` against `to_delete` as plain strings:

```python
def remove_real_and_linked_file(to_delete):
    if (os.path.realpath(to_delete) != to_delete):
        targetpath = os.path.realpath(to_delete)

    os.remove(to_delete)
    if (targetpath):
         os.remove(targetpath)
```

`os.path.realpath()` always returns a normalized absolute path. So this comparison also trips for perfectly ordinary files whose path isn't already absolute (any relative path), or an absolute path that just isn't already fully normalized — not just for actual symlinks. When that happens, `targetpath` gets set to the *same underlying file* under its resolved name, and the second `os.remove()` call tries to delete a file the first call already removed:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../shard.bin'
```

If the paths happen to compare equal as strings instead (e.g. an absolute, already-normalized path to a genuinely regular file), `targetpath` is never assigned at all, and `if (targetpath):` raises instead:

```
UnboundLocalError: cannot access local variable 'targetpath' where it is not associated with a value
```

`split_and_save_layers()` calls this helper whenever `delete_original=True`, both mid-split for multi-shard checkpoints and at the end for single-file ones, so either crash reproduces any time that flag is used against a checkpoint that isn't reached through a symlink — e.g. any local model directory passed with a relative path.

Fixes #297.

## Fix

Use `os.path.islink()`, which answers the actual question ("is this a symlink whose target should also be removed?") regardless of whether the path is relative, absolute, or already normalized:

```python
def remove_real_and_linked_file(to_delete):
    targetpath = os.path.realpath(to_delete) if os.path.islink(to_delete) else None

    os.remove(to_delete)
    if targetpath:
        os.remove(targetpath)
```

## Testing

Added `air_llm/tests/test_remove_real_and_linked_file.py` covering the three cases: a normal absolute file, a normal relative file, and a symlink plus its target. All three pass against the fix; against the pre-fix code, the two normal-file cases fail with the errors above (confirmed locally by temporarily reverting the fix and re-running).