### PR TITLE
Prefer safetensors over pickle .bin when splitting model layers (fixes #296)

### DIFF
--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -204,6 +204,54 @@ def remove_real_and_linked_file(to_delete):
          os.remove(targetpath)
 
 
+def _resolve_weight_map(checkpoint_path):
+    """
+    Pick which on-disk checkpoint to split and return ``(weight_map, safetensors_format)``.
+
+    Prefer safetensors over pickle-based ``pytorch_model.bin`` whenever both are present. safetensors
+    is the ecosystem default, is memory-mapped, and -- unlike a ``.bin`` file, which is a Python
+    pickle -- cannot execute arbitrary code when read. AirLLM's advertised entry point is an
+    arbitrary Hugging Face repo id, so a repo that ships both formats should never be unpickled just
+    because the pickle index happened to be checked first. We only fall back to ``.bin`` when no
+    safetensors weights exist. (The single-file branch already preferred safetensors; the multi-shard
+    branch used to check ``pytorch_model.bin.index.json`` first, which was both inconsistent with the
+    single-file branch and needlessly unsafe.)
+
+    ``weight_map`` maps each parameter name to the file that stores it. Multi-shard checkpoints ship
+    an ``index.json`` with this map; single-file checkpoints have no index, so synthesize one that
+    points every tensor at the lone file.
+    """
+    checkpoint_path = Path(checkpoint_path)
+
+    # 1. sharded safetensors
+    if os.path.exists(checkpoint_path / 'model.safetensors.index.json'):
+        with open(checkpoint_path / 'model.safetensors.index.json', 'rb') as f:
+            return json.load(f)['weight_map'], True
+
+    # 2. single-file safetensors
+    if os.path.exists(checkpoint_path / 'model.safetensors'):
+        from safetensors import safe_open
+        with safe_open(str(checkpoint_path / 'model.safetensors'), framework='pt') as f:
+            return {k: 'model.safetensors' for k in f.keys()}, True
+
+    # 3. sharded torch pickle
+    if os.path.exists(checkpoint_path / 'pytorch_model.bin.index.json'):
+        with open(checkpoint_path / 'pytorch_model.bin.index.json', 'rb') as f:
+            return json.load(f)['weight_map'], False
+
+    # 4. single-file torch pickle. weights_only=True restricts the unpickler to tensors and a safe
+    # allowlist, so reading the keys of an untrusted checkpoint can't run arbitrary code.
+    if os.path.exists(checkpoint_path / 'pytorch_model.bin'):
+        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu',
+                               weights_only=True)
+        index = {k: 'pytorch_model.bin' for k in single_sd.keys()}
+        del single_sd
+        return index, False
+
+    raise FileNotFoundError(
+        f"No model weights found under {checkpoint_path}. Expected one of: "
+        f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
+
 
 def link_or_copy_file(src, dst):
     """Point dst at src's data without duplicating it, falling back to a real copy.
@@ -251,32 +299,8 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         saving_path = Path(layer_shards_saving_path) / splitted_model_dir_name
 
 
-    # Build a weight_map (param name -> file that stores it). Multi-shard checkpoints ship an
-    # index.json; small/modern models often ship a single file with no index, so synthesize one.
-    safetensors_format = False
-    if os.path.exists(checkpoint_path / 'pytorch_model.bin.index.json'):
-        with open(checkpoint_path / 'pytorch_model.bin.index.json', 'rb') as f:
-            index = json.load(f)['weight_map']
-    elif os.path.exists(checkpoint_path / 'model.safetensors.index.json'):
-        safetensors_format = True
-        with open(checkpoint_path / 'model.safetensors.index.json', 'rb') as f:
-            index = json.load(f)['weight_map']
-    elif os.path.exists(checkpoint_path / 'model.safetensors'):
-        # single-file safetensors checkpoint: map every tensor to that one file
-        safetensors_format = True
-        from safetensors import safe_open
-        with safe_open(str(checkpoint_path / 'model.safetensors'), framework='pt') as f:
-            index = {k: 'model.safetensors' for k in f.keys()}
-    elif os.path.exists(checkpoint_path / 'pytorch_model.bin'):
-        # single-file torch checkpoint: map every tensor to that one file
-        safetensors_format = False
-        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu')
-        index = {k: 'pytorch_model.bin' for k in single_sd.keys()}
-        del single_sd
-    else:
-        raise FileNotFoundError(
-            f"No model weights found under {checkpoint_path}. Expected one of: "
-            f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
+    # Build a weight_map (param name -> file that stores it), preferring safetensors over pickle.
+    index, safetensors_format = _resolve_weight_map(checkpoint_path)
 
     if layer_names is None:
         n_layers = len(set([int(k.split('.')[2]) for k in index.keys() if 'model.layers' in k]))
@@ -431,7 +455,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                                                     token=hf_token)
 
                 if not safetensors_format:
-                    state_dict.update(torch.load(to_load, map_location='cpu'))
+                    state_dict.update(torch.load(to_load, map_location='cpu', weights_only=True))
                 else:
                     state_dict.update(load_file(to_load, device='cpu'))
 
@@ -445,7 +469,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 huggingface_hub.snapshot_download(repo_id, allow_patterns=os.path.basename(to_load),
                                                 token=hf_token)
             if not safetensors_format:
-                state_dict.update(torch.load(to_load, map_location='cpu'))
+                state_dict.update(torch.load(to_load, map_location='cpu', weights_only=True))
             else:
                 state_dict.update(load_file(to_load, device='cpu'))
 

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -497,6 +497,54 @@ def remove_real_and_linked_file(to_delete):
          os.remove(targetpath)
 
 
+def _resolve_weight_map(checkpoint_path):
+    """
+    Pick which on-disk checkpoint to split and return ``(weight_map, safetensors_format)``.
+
+    Prefer safetensors over pickle-based ``pytorch_model.bin`` whenever both are present. safetensors
+    is the ecosystem default, is memory-mapped, and -- unlike a ``.bin`` file, which is a Python
+    pickle -- cannot execute arbitrary code when read. AirLLM's advertised entry point is an
+    arbitrary Hugging Face repo id, so a repo that ships both formats should never be unpickled just
+    because the pickle index happened to be checked first. We only fall back to ``.bin`` when no
+    safetensors weights exist. (The single-file branch already preferred safetensors; the multi-shard
+    branch used to check ``pytorch_model.bin.index.json`` first, which was both inconsistent with the
+    single-file branch and needlessly unsafe.)
+
+    ``weight_map`` maps each parameter name to the file that stores it. Multi-shard checkpoints ship
+    an ``index.json`` with this map; single-file checkpoints have no index, so synthesize one that
+    points every tensor at the lone file.
+    """
+    checkpoint_path = Path(checkpoint_path)
+
+    # 1. sharded safetensors
+    if os.path.exists(checkpoint_path / 'model.safetensors.index.json'):
+        with open(checkpoint_path / 'model.safetensors.index.json', 'rb') as f:
+            return json.load(f)['weight_map'], True
+
+    # 2. single-file safetensors
+    if os.path.exists(checkpoint_path / 'model.safetensors'):
+        from safetensors import safe_open
+        with safe_open(str(checkpoint_path / 'model.safetensors'), framework='pt') as f:
+            return {k: 'model.safetensors' for k in f.keys()}, True
+
+    # 3. sharded torch pickle
+    if os.path.exists(checkpoint_path / 'pytorch_model.bin.index.json'):
+        with open(checkpoint_path / 'pytorch_model.bin.index.json', 'rb') as f:
+            return json.load(f)['weight_map'], False
+
+    # 4. single-file torch pickle. weights_only=True restricts the unpickler to tensors and a safe
+    # allowlist, so reading the keys of an untrusted checkpoint can't run arbitrary code.
+    if os.path.exists(checkpoint_path / 'pytorch_model.bin'):
+        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu',
+                               weights_only=True)
+        index = {k: 'pytorch_model.bin' for k in single_sd.keys()}
+        del single_sd
+        return index, False
+
+    raise FileNotFoundError(
+        f"No model weights found under {checkpoint_path}. Expected one of: "
+        f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
+
 
 def link_or_copy_file(src, dst):
     """Point dst at src's data without duplicating it, falling back to a real copy.
@@ -544,32 +592,8 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         saving_path = Path(layer_shards_saving_path) / splitted_model_dir_name
 
 
-    # Build a weight_map (param name -> file that stores it). Multi-shard checkpoints ship an
-    # index.json; small/modern models often ship a single file with no index, so synthesize one.
-    safetensors_format = False
-    if os.path.exists(checkpoint_path / 'pytorch_model.bin.index.json'):
-        with open(checkpoint_path / 'pytorch_model.bin.index.json', 'rb') as f:
-            index = json.load(f)['weight_map']
-    elif os.path.exists(checkpoint_path / 'model.safetensors.index.json'):
-        safetensors_format = True
-        with open(checkpoint_path / 'model.safetensors.index.json', 'rb') as f:
-            index = json.load(f)['weight_map']
-    elif os.path.exists(checkpoint_path / 'model.safetensors'):
-        # single-file safetensors checkpoint: map every tensor to that one file
-        safetensors_format = True
-        from safetensors import safe_open
-        with safe_open(str(checkpoint_path / 'model.safetensors'), framework='pt') as f:
-            index = {k: 'model.safetensors' for k in f.keys()}
-    elif os.path.exists(checkpoint_path / 'pytorch_model.bin'):
-        # single-file torch checkpoint: map every tensor to that one file
-        safetensors_format = False
-        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu')
-        index = {k: 'pytorch_model.bin' for k in single_sd.keys()}
-        del single_sd
-    else:
-        raise FileNotFoundError(
-            f"No model weights found under {checkpoint_path}. Expected one of: "
-            f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
+    # Build a weight_map (param name -> file that stores it), preferring safetensors over pickle.
+    index, safetensors_format = _resolve_weight_map(checkpoint_path)
 
     if layer_names is None:
         n_layers = len(set([int(k.split('.')[2]) for k in index.keys() if 'model.layers' in k]))
@@ -735,7 +759,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                                                     token=hf_token)
 
                 if not safetensors_format:
-                    loaded = torch.load(to_load, map_location='cpu')
+                    loaded = torch.load(to_load, map_location='cpu', weights_only=True)
                 else:
                     loaded = load_file(to_load, device='cpu')
                 marker = (layer_names or {}).get('cpu_resident_marker')
@@ -753,7 +777,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 huggingface_hub.snapshot_download(repo_id, allow_patterns=os.path.basename(to_load),
                                                 token=hf_token)
             if not safetensors_format:
-                loaded = torch.load(to_load, map_location='cpu')
+                loaded = torch.load(to_load, map_location='cpu', weights_only=True)
             else:
                 loaded = load_file(to_load, device='cpu')
             marker = (layer_names or {}).get('cpu_resident_marker')

--- a/air_llm/tests/test_weight_index_resolution.py
+++ b/air_llm/tests/test_weight_index_resolution.py
@@ -1,0 +1,87 @@
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+from safetensors.torch import save_file
+
+from airllm.utils import _resolve_weight_map
+
+
+class TestResolveWeightMap(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = self.tmpdir.name
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _write_index(self, name, weight_map):
+        with open(os.path.join(self.root, name), 'w') as f:
+            json.dump({'metadata': {}, 'weight_map': weight_map}, f)
+
+    def _write_safetensors(self, name):
+        save_file({'w': torch.zeros(2)}, os.path.join(self.root, name))
+
+    def _write_bin(self, name):
+        torch.save({'w': torch.zeros(2)}, os.path.join(self.root, name))
+
+    def test_prefers_safetensors_index_when_both_indexes_present(self):
+        # A repo that ships both formats must not be unpickled just because the .bin index exists.
+        self._write_index('pytorch_model.bin.index.json',
+                          {'w': 'pytorch_model-00001-of-00001.bin'})
+        self._write_index('model.safetensors.index.json',
+                          {'w': 'model-00001-of-00001.safetensors'})
+
+        index, safetensors_format = _resolve_weight_map(self.root)
+
+        self.assertTrue(safetensors_format)
+        self.assertEqual(index['w'], 'model-00001-of-00001.safetensors')
+
+    def test_falls_back_to_bin_index_when_only_bin_present(self):
+        self._write_index('pytorch_model.bin.index.json',
+                          {'w': 'pytorch_model-00001-of-00001.bin'})
+
+        index, safetensors_format = _resolve_weight_map(self.root)
+
+        self.assertFalse(safetensors_format)
+        self.assertEqual(index['w'], 'pytorch_model-00001-of-00001.bin')
+
+    def test_prefers_single_file_safetensors_over_single_file_bin(self):
+        self._write_safetensors('model.safetensors')
+        self._write_bin('pytorch_model.bin')
+
+        index, safetensors_format = _resolve_weight_map(self.root)
+
+        self.assertTrue(safetensors_format)
+        self.assertEqual(set(index.values()), {'model.safetensors'})
+
+    def test_single_file_bin_loads_with_weights_only(self):
+        # The single-file .bin branch must read keys without executing pickle payloads.
+        self._write_bin('pytorch_model.bin')
+
+        real_load = torch.load
+        seen = {}
+
+        def spy(*args, **kwargs):
+            seen['weights_only'] = kwargs.get('weights_only')
+            return real_load(*args, **kwargs)
+
+        torch.load = spy
+        try:
+            index, safetensors_format = _resolve_weight_map(self.root)
+        finally:
+            torch.load = real_load
+
+        self.assertFalse(safetensors_format)
+        self.assertEqual(seen.get('weights_only'), True)
+        self.assertIn('w', index)
+
+    def test_raises_when_no_weights_present(self):
+        with self.assertRaises(FileNotFoundError):
+            _resolve_weight_map(self.root)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Make the layer splitter prefer safetensors over pickle-based `pytorch_model.bin`, and read any `.bin` it does load with `weights_only=True`.

Fixes #296.

## Why

`split_and_save_layers()` resolved the weight map in this order:

```python
if os.path.exists(checkpoint_path / 'pytorch_model.bin.index.json'):
    ...            # <- .bin checked first
elif os.path.exists(checkpoint_path / 'model.safetensors.index.json'):
    ...
```

Two problems with checking `.bin` first:

1. **Inconsistent with the single-file branch**, which already preferred `model.safetensors` over `pytorch_model.bin`. So a repo's sharded path and single-file path made opposite choices for the same repo.
2. **Unnecessary pickle loading.** `.bin` shards are Python pickles loaded through `torch.load()`. AirLLM's advertised entry point is an arbitrary Hugging Face repo id (`AutoModel.from_pretrained("some/repo")`), so when a repo ships *both* formats — many still do — AirLLM would download and unpickle the `.bin` shards during the split even though the safe, memory-mapped safetensors were sitting right there. `torch.load()` documents that unpickling untrusted data can execute arbitrary code.

This aligns the sharded path with the single-file path and with the rest of the ecosystem (transformers itself prefers safetensors when both exist), and it means the common "repo ships both" case no longer touches the pickle path at all.

## Changes

- Extract weight-map resolution into a small `_resolve_weight_map(checkpoint_path)` helper with a clear preference order: sharded safetensors → single-file safetensors → sharded `.bin` → single-file `.bin`. `.bin` is still fully supported as a fallback; nothing is removed.
- Pass `weights_only=True` to every `torch.load()` of a checkpoint shard. This restricts the unpickler to tensors and a safe allowlist. `setup.py` already requires `torch>=2.4`, where this argument is fully supported (PyTorch made it the default in 2.6), so there's no compatibility cost — and model weight files are plain tensor state dicts, which load fine under it.
- Add `air_llm/tests/test_weight_index_resolution.py` with offline unit tests.

## Testing

New offline unit tests (no network, no GPU) — `python -m pytest air_llm/tests/test_weight_index_resolution.py`:

- safetensors index preferred when both indexes are present
- falls back to the `.bin` index when only `.bin` exists
- single-file safetensors preferred over single-file `.bin`
- single-file `.bin` is loaded with `weights_only=True`
- `FileNotFoundError` when no weights are present

All 5 pass. I also ran `split_and_save_layers()` end-to-end on a tiny fake checkpoint that ships **both** formats and confirmed it now splits from safetensors and produces all per-layer shards, with no change to the resulting layout.
