### PR TITLE
Default to trust_remote_code=False, fall back only when required (addresses #293)

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -15,7 +15,7 @@ from transformers.quantizers import AutoHfQuantizer
 from .profiler import LayeredProfiler
 
 from .utils import clean_memory, load_layer, layer_tensor_names, load_layer_subset, \
-    find_or_create_local_splitted_path
+    find_or_create_local_splitted_path, load_prefer_no_remote_code
 from .persist import ModelPersister
 
 try:
@@ -203,10 +203,11 @@ class AirLLMBaseModel:
             return GenerationConfig()
 
     def get_tokenizer(self, hf_token=None):
-        if hf_token is not None:
-            return AutoTokenizer.from_pretrained(self.model_local_path, token=hf_token, trust_remote_code=True)
-        else:
-            return AutoTokenizer.from_pretrained(self.model_local_path, trust_remote_code=True)
+        token_kwargs = {'token': hf_token} if hf_token is not None else {}
+        # Prefer transformers' native tokenizer; only trust the repo's remote code if it's required
+        # (custom tokenizers). Matches how the config/model are loaded above.
+        return load_prefer_no_remote_code(
+            AutoTokenizer.from_pretrained, self.model_local_path, **token_kwargs)
 
     # ---- model construction -----------------------------------------------------------------
 

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -16,8 +16,8 @@ from transformers.quantizers import AutoHfQuantizer
 from .profiler import LayeredProfiler
 
 from .utils import clean_memory, load_layer, layer_tensor_names, load_layer_subset, \
-    find_or_create_local_splitted_path, load_merged_ngram_embedding, \
-    open_ngram_mmap_table, MmapEmbedding, _force_meta_embeddings
+    find_or_create_local_splitted_path, load_prefer_no_remote_code, \
+    load_merged_ngram_embedding, open_ngram_mmap_table, MmapEmbedding, _force_meta_embeddings
 from .persist import ModelPersister
 
 try:
@@ -211,10 +211,11 @@ class AirLLMBaseModel:
             return GenerationConfig()
 
     def get_tokenizer(self, hf_token=None):
-        if hf_token is not None:
-            return AutoTokenizer.from_pretrained(self.model_local_path, token=hf_token, trust_remote_code=True)
-        else:
-            return AutoTokenizer.from_pretrained(self.model_local_path, trust_remote_code=True)
+        token_kwargs = {'token': hf_token} if hf_token is not None else {}
+        # Prefer transformers' native tokenizer; only trust the repo's remote code if it's required
+        # (custom tokenizers). Matches how the config/model are loaded above.
+        return load_prefer_no_remote_code(
+            AutoTokenizer.from_pretrained, self.model_local_path, **token_kwargs)
 
     # ---- model construction -----------------------------------------------------------------
 

--- a/air_llm/airllm/airllm_llama_mlx.py
+++ b/air_llm/airllm/airllm_llama_mlx.py
@@ -15,7 +15,7 @@ from .persist import ModelPersister
 import psutil
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, AutoModel, GenerationMixin, LlamaForCausalLM, GenerationConfig
 from .utils import clean_memory, load_layer, \
-    find_or_create_local_splitted_path
+    find_or_create_local_splitted_path, load_prefer_no_remote_code
 
 
 
@@ -227,10 +227,9 @@ class AirLLMLlamaMlx:
                                                                                          layer_names=self.layer_names_dict,
                                                                                          hf_token=hf_token,
                                                                                          delete_original=delete_original)
-        if hf_token is not None:
-            self.config = AutoConfig.from_pretrained(self.model_local_path, token=hf_token, trust_remote_code=True)
-        else:
-            self.config = AutoConfig.from_pretrained(self.model_local_path, trust_remote_code=True)
+        token_kwargs = {'token': hf_token} if hf_token is not None else {}
+        self.config = load_prefer_no_remote_code(
+            AutoConfig.from_pretrained, self.model_local_path, **token_kwargs)
 
 
         self.model_args = get_model_args_from_config(self.config)
@@ -243,10 +242,9 @@ class AirLLMLlamaMlx:
 
 
     def get_tokenizer(self, hf_token=None):
-        if hf_token is not None:
-            return AutoTokenizer.from_pretrained(self.model_local_path, token=hf_token, trust_remote_code=True)
-        else:
-            return AutoTokenizer.from_pretrained(self.model_local_path, trust_remote_code=True)
+        token_kwargs = {'token': hf_token} if hf_token is not None else {}
+        return load_prefer_no_remote_code(
+            AutoTokenizer.from_pretrained, self.model_local_path, **token_kwargs)
 
 
     def generate(self, x, temperature=0, max_new_tokens=None, **kwargs):

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -2,6 +2,8 @@ import importlib
 from transformers import AutoConfig
 from sys import platform
 
+from .utils import load_prefer_no_remote_code
+
 is_on_mac_os = False
 
 if platform == "darwin":
@@ -34,11 +36,11 @@ class AutoModel:
 
     @classmethod
     def get_module_class(cls, pretrained_model_name_or_path, *inputs, **kwargs):
-        if 'hf_token' in kwargs:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True,
-                                                token=kwargs['hf_token'])
-        else:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
+        token_kwargs = {'token': kwargs['hf_token']} if 'hf_token' in kwargs else {}
+        # Prefer transformers' native config; only run the repo's remote code if it's actually
+        # required to parse the config (custom architectures). See load_prefer_no_remote_code.
+        config = load_prefer_no_remote_code(
+            AutoConfig.from_pretrained, pretrained_model_name_or_path, **token_kwargs)
 
         architectures = getattr(config, "architectures", None) or []
         arch = architectures[0] if architectures else ""

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -2,6 +2,8 @@ import importlib
 from transformers import AutoConfig
 from sys import platform
 
+from .utils import load_prefer_no_remote_code
+
 is_on_mac_os = False
 
 if platform == "darwin":
@@ -36,11 +38,11 @@ class AutoModel:
 
     @classmethod
     def get_module_class(cls, pretrained_model_name_or_path, *inputs, **kwargs):
-        if 'hf_token' in kwargs:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True,
-                                                token=kwargs['hf_token'])
-        else:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
+        token_kwargs = {'token': kwargs['hf_token']} if 'hf_token' in kwargs else {}
+        # Prefer transformers' native config; only run the repo's remote code if it's actually
+        # required to parse the config (custom architectures). See load_prefer_no_remote_code.
+        config = load_prefer_no_remote_code(
+            AutoConfig.from_pretrained, pretrained_model_name_or_path, **token_kwargs)
 
         architectures = getattr(config, "architectures", None) or []
         arch = architectures[0] if architectures else ""

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -83,6 +83,24 @@ def clean_memory():
     torch.cuda.empty_cache()
 
 
+def load_prefer_no_remote_code(loader, *args, **kwargs):
+    """
+    Call a transformers ``from_pretrained``-style loader, preferring transformers' native
+    implementation and only trusting the model's bundled remote code when the native load fails.
+
+    AirLLM's advertised entry point is an arbitrary Hugging Face repo id, so a normal load of a
+    standard architecture should not execute Python shipped in the repo. Standard models load fine
+    with ``trust_remote_code=False``; only models that genuinely ship custom code (ChatGLM, Baichuan,
+    some Qwen) raise without it, so we fall back to ``trust_remote_code=True`` for those. This mirrors
+    how ``AirLLMBaseModel`` already loads the model config/weights, and keeps every load boundary
+    (config, tokenizer, model) consistent instead of hard-coding ``trust_remote_code=True``.
+    """
+    try:
+        return loader(*args, trust_remote_code=False, **kwargs)
+    except Exception:
+        return loader(*args, trust_remote_code=True, **kwargs)
+
+
 def uncompress_layer_state_dict(layer_state_dict):
     uncompressed_layer_state_dict = None
     if any(['4bit' in k for k in layer_state_dict.keys()]):

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -85,6 +85,24 @@ def clean_memory():
     torch.cuda.empty_cache()
 
 
+def load_prefer_no_remote_code(loader, *args, **kwargs):
+    """
+    Call a transformers ``from_pretrained``-style loader, preferring transformers' native
+    implementation and only trusting the model's bundled remote code when the native load fails.
+
+    AirLLM's advertised entry point is an arbitrary Hugging Face repo id, so a normal load of a
+    standard architecture should not execute Python shipped in the repo. Standard models load fine
+    with ``trust_remote_code=False``; only models that genuinely ship custom code (ChatGLM, Baichuan,
+    some Qwen) raise without it, so we fall back to ``trust_remote_code=True`` for those. This mirrors
+    how ``AirLLMBaseModel`` already loads the model config/weights, and keeps every load boundary
+    (config, tokenizer, model) consistent instead of hard-coding ``trust_remote_code=True``.
+    """
+    try:
+        return loader(*args, trust_remote_code=False, **kwargs)
+    except Exception:
+        return loader(*args, trust_remote_code=True, **kwargs)
+
+
 def uncompress_layer_state_dict(layer_state_dict):
     uncompressed_layer_state_dict = None
     if any(['4bit' in k for k in layer_state_dict.keys()]):

--- a/air_llm/tests/test_trust_remote_code.py
+++ b/air_llm/tests/test_trust_remote_code.py
@@ -1,0 +1,95 @@
+import unittest
+
+import airllm.auto_model as auto_model_mod
+from airllm.auto_model import AutoModel
+from airllm.utils import load_prefer_no_remote_code
+
+
+class _FakeConfig:
+    def __init__(self, architectures):
+        self.architectures = architectures
+
+
+class TestLoadPreferNoRemoteCode(unittest.TestCase):
+    def test_uses_false_and_does_not_retry_when_native_load_succeeds(self):
+        calls = []
+
+        def loader(path, trust_remote_code=None, **kwargs):
+            calls.append(trust_remote_code)
+            return 'ok'
+
+        result = load_prefer_no_remote_code(loader, 'some/repo')
+
+        self.assertEqual(result, 'ok')
+        self.assertEqual(calls, [False])  # tried False, never fell back to True
+
+    def test_falls_back_to_true_when_native_load_raises(self):
+        calls = []
+
+        def loader(path, trust_remote_code=None, **kwargs):
+            calls.append(trust_remote_code)
+            if trust_remote_code is False:
+                raise ValueError('requires trust_remote_code=True')
+            return 'ok-remote'
+
+        result = load_prefer_no_remote_code(loader, 'custom/repo')
+
+        self.assertEqual(result, 'ok-remote')
+        self.assertEqual(calls, [False, True])  # tried False first, then True
+
+    def test_forwards_extra_kwargs(self):
+        seen = {}
+
+        def loader(path, trust_remote_code=None, **kwargs):
+            seen.update(kwargs)
+            seen['path'] = path
+            return 'ok'
+
+        load_prefer_no_remote_code(loader, 'some/repo', token='abc')
+
+        self.assertEqual(seen['path'], 'some/repo')
+        self.assertEqual(seen['token'], 'abc')
+
+
+class TestGetModuleClassTrust(unittest.TestCase):
+    """AutoModel.get_module_class must not enable remote code unless it is actually required."""
+
+    def setUp(self):
+        self._orig = auto_model_mod.AutoConfig.from_pretrained
+
+    def tearDown(self):
+        auto_model_mod.AutoConfig.from_pretrained = self._orig
+
+    def test_standard_arch_loads_config_without_remote_code(self):
+        calls = []
+
+        def fake(path, trust_remote_code=None, **kwargs):
+            calls.append(trust_remote_code)
+            return _FakeConfig(['LlamaForCausalLM'])
+
+        auto_model_mod.AutoConfig.from_pretrained = staticmethod(fake)
+
+        module, cls = AutoModel.get_module_class('some/llama-repo')
+
+        self.assertEqual((module, cls), ('airllm', 'AirLLMBaseModel'))
+        self.assertEqual(calls, [False])  # native path only; remote code never enabled
+
+    def test_custom_arch_falls_back_to_remote_code(self):
+        calls = []
+
+        def fake(path, trust_remote_code=None, **kwargs):
+            calls.append(trust_remote_code)
+            if trust_remote_code is False:
+                raise ValueError('requires trust_remote_code=True')
+            return _FakeConfig(['ChatGLMModel'])
+
+        auto_model_mod.AutoConfig.from_pretrained = staticmethod(fake)
+
+        module, cls = AutoModel.get_module_class('some/chatglm-repo')
+
+        self.assertEqual((module, cls), ('airllm', 'AirLLMChatGLM'))
+        self.assertEqual(calls, [False, True])  # only trusts remote code as a fallback
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Stop hard-coding `trust_remote_code=True` at the config and tokenizer load boundaries. Instead prefer transformers' native implementation and only fall back to the repo's remote code when it's actually required.

Addresses #293. (Left as "addresses" rather than "fixes" — see *Scope* below.)

## Why

`AirLLMBaseModel` already loads the model config/weights this way — it tries `trust_remote_code=False` and only falls back to `True` when transformers can't parse the model natively (base.py:113–120, 185/194). But two other load boundaries still passed `trust_remote_code=True` unconditionally:

- `AutoModel.get_module_class()` — the **config** load, which runs first, before the model is even constructed (auto_model.py).
- `AirLLMBaseModel.get_tokenizer()` and the MLX path's config + tokenizer loads.

Since AirLLM's advertised entry point is an arbitrary Hugging Face repo id (`AutoModel.from_pretrained("some/repo")`), those unconditional `True`s mean a normal load of a *standard* architecture (Llama, Qwen3, Mistral, …) would still execute Python shipped in the repo, with no way for the caller to stay on transformers' default remote-code boundary.

This PR makes every load boundary consistent with the pattern the model loading already uses.

## Changes

- Add `load_prefer_no_remote_code(loader, *args, **kwargs)` in `utils.py`: try the loader with `trust_remote_code=False`, fall back to `trust_remote_code=True` only if the native load raises.
- Use it for the config load in `AutoModel.get_module_class`, the tokenizer load in `AirLLMBaseModel`, and the config + tokenizer loads in `AirLLMLlamaMlx`.
- Add offline unit tests.

**Behavior:** standard models no longer trigger remote-code execution during config/tokenizer loading. Models that genuinely ship custom code (ChatGLM, Baichuan, some Qwen) still work because the fallback re-loads with `trust_remote_code=True`. **No API change**, no new required arguments.

## Scope / what this deliberately does *not* do

This mirrors your existing auto-fallback approach rather than adding a new public `trust_remote_code=` parameter. The auto-fallback is a strict improvement (the common case stops running remote code) but it does **not** give a hard opt-out: a repo that genuinely requires remote code will still run it via the fallback. A follow-up could add an explicit `trust_remote_code: Optional[bool] = None` kwarg (None = current auto behavior, `False` = hard refuse, `True` = force) for callers who want a guarantee. I left that out here to keep the change minimal and consistent with the current design — happy to add it if you'd prefer. That's also why this says "Addresses" rather than "Fixes" #293, so the issue stays open for that decision.

## Testing

`python -m pytest air_llm/tests/test_trust_remote_code.py` — 5 offline tests (no network, no GPU), all pass:

- helper uses `trust_remote_code=False` and does **not** retry when the native load succeeds
- helper falls back to `True` when the `False` load raises
- helper forwards extra kwargs (e.g. `token`)
- `get_module_class` loads a standard arch's config with `trust_remote_code=False` only
- `get_module_class` falls back to `True` for a custom arch (e.g. ChatGLM) and still resolves the right class

Note: the MLX path is changed identically but I couldn't run it locally (no Apple silicon) — it's a mechanical mirror of the generic path using the same tested helper.
