### PR TITLE
Add GLM-5.2 and Kimi streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,91 @@ When initialize the model, we support the following configurations:
 * **hf_token**: huggingface token can be provided here if downloading gated models like: *meta-llama/Llama-2-7b-hf*
 * **prefetching**: prefetching to overlap the model loading and compute. By default, turned on. For now, only AirLLMLlama2 supports this.
 * **delete_original**: if you don't have too much disk space, you can set delete_original to true to delete the original downloaded hugging face model, only keep the transformed one to save half of the disk space. 
+* **cache_dir**: optional Hugging Face download-cache path. For checkpoints larger than the system drive, put both `cache_dir` and `layer_shards_saving_path` on a large local SSD.
+
+### Preflight very large checkpoints
+
+Inspect the model config, weight index, layer layout and required offload capacity before downloading weight shards:
+
+```bash
+airllm-preflight --model zai-org/GLM-5.2-FP8 --offload-dir D:\\airllm-models
+airllm-preflight --model moonshotai/Kimi-K2.7-Code --offload-dir D:\\airllm-models
+```
+
+The GLM-5.2-FP8 checkpoint is about 704 GiB and Kimi-K2.7-Code is about 554 GiB before AirLLM's layer split. The split is approximately the same size for these already-quantized checkpoints. `delete_original=True` prevents retaining a second full checkpoint copy, but the final split still has to fit on the offload volume.
+
+For Kimi K2.5/K2.6/K2.7, install the packed-weight loader and use a dedicated environment whose Transformers version matches the model card:
+
+```bash
+pip install -e "./air_llm[kimi]"
+```
+
+GLM-5.2 uses Transformers 5.12, so keep GLM and Kimi in separate virtual environments:
+
+```bash
+pip install -e "./air_llm[glm52]"
+```
+
+The Kimi path is text-only. AirLLM rejects image or video inputs because the vision tower is not layer-streamed yet.
+Its published packed INT4 weights are kept packed while a layer is resident; AirLLM dequantizes one Linear projection at a time instead of allowing `compressed-tensors` to expand the whole model on first use.
+
+Example with an external local SSD:
+
+```python
+from airllm import AutoModel
+
+model = AutoModel.from_pretrained(
+    "zai-org/GLM-5.2-FP8",
+    cache_dir=r"D:\\airllm-cache",
+    layer_shards_saving_path=r"D:\\airllm-models",
+    delete_original=True,
+    prefetching=False,
+)
+```
+
+For GLM-5.2-FP8, AirLLM preserves the checkpoint's per-expert layout and uses a portable projection-at-a-time dequantization fallback. This works without the optional CUDA/Triton FP8 kernels, including on PyTorch ROCm, but is slower than optimized multi-GPU engines. Do not pass `compression="4bit"` or `compression="8bit"` to an already-quantized GLM or Kimi checkpoint.
+
+### Windows and AMD Radeon
+
+On Windows, enable UTF-8 before importing Kimi's `compressed-tensors` dependencies. Install the AMD-supported ROCm PyTorch build for the GPU architecture; RX 9070 XT is `gfx1201`:
+
+```powershell
+$env:PYTHONUTF8 = "1"
+py -3.12 -m venv .venv-glm
+.\.venv-glm\Scripts\Activate.ps1
+python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1201]==2.12.0+rocm7.14.0" "torchvision[device-gfx1201]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install -e ".\air_llm[glm52,server]"
+```
+
+Use a separate virtual environment for Kimi because its official remote code requires Transformers 4.x:
+
+```powershell
+$env:PYTHONUTF8 = "1"
+py -3.12 -m venv .venv-kimi
+.\.venv-kimi\Scripts\Activate.ps1
+python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1201]==2.12.0+rocm7.14.0" "torchvision[device-gfx1201]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"
+python -m pip install -e ".\air_llm[kimi,server]"
+```
+
+The current PyPI `bitsandbytes` Windows wheel may install without a usable ROCm native library. AirLLM now detects that case before downloading weights. Prefer the published FP8/INT4 checkpoints instead of AirLLM's optional bitsandbytes compression on this platform.
+
+### Local chat-completions API
+
+Install the optional server dependencies and start the non-streaming, text-only endpoint. It binds to localhost by default:
+
+```bash
+pip install -e "./air_llm[server]"
+airllm-serve --model zai-org/GLM-5.2-FP8 \
+  --cache-dir D:\\airllm-cache --offload-dir D:\\airllm-models --delete-original --no-prefetch
+```
+
+```bash
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"zai-org/GLM-5.2-FP8","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}'
+```
+
+The API implements `GET /health`, `GET /v1/models`, and non-streaming `POST /v1/chat/completions`. AirLLM serializes requests because one model instance streams mutable layer state.
 
 ## MacOS
 

--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -15,6 +15,7 @@ else:
     from .auto_model import AutoModel
     from .utils import split_and_save_layers
     from .utils import NotEnoughSpaceException
+    from .utils import compress_layer_state_dict, uncompress_layer_state_dict
 
     # Dedicated subclasses for a handful of custom-architecture models. Some of them pull in
     # optional extras (e.g. the Baichuan tokenizer needs `sentencepiece`). Import them defensively
@@ -31,6 +32,8 @@ else:
         ("AirLLMInternLM", ".airllm_internlm"),
         ("AirLLMMistral", ".airllm_mistral"),
         ("AirLLMMixtral", ".airllm_mixtral"),
+        ("AirLLMKimiK25", ".airllm_kimi_k25"),
+        ("AirLLMGlmMoeDsa", ".airllm_glm_moe_dsa"),
     ):
         try:
             _mod = __import__(__name__ + _module, fromlist=[_name])

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -14,15 +14,7 @@ from transformers.quantizers import AutoHfQuantizer
 from .profiler import LayeredProfiler
 
 from .utils import clean_memory, load_layer, \
-    find_or_create_local_splitted_path
-
-try:
-    import bitsandbytes as bnb
-
-    bitsandbytes_installed = True
-    print('>>>> bitsandbytes installed')
-except ImportError:
-    bitsandbytes_installed = False
+    find_or_create_local_splitted_path, require_bitsandbytes
 
 
 class AirLLMBaseModel:
@@ -49,7 +41,7 @@ class AirLLMBaseModel:
 
     def __init__(self, model_local_path_or_repo_id, device="cuda:0", dtype=None, max_seq_len=512,
                  layer_shards_saving_path=None, profiling_mode=False, compression=None,
-                 hf_token=None, prefetching=True, delete_original=False):
+                 hf_token=None, prefetching=True, delete_original=False, cache_dir=None):
         """
         Parameters
         ----------
@@ -75,6 +67,9 @@ class AirLLMBaseModel:
             overlap the next layer's disk load with the current layer's compute
         delete_original: bool, optional
             delete the original downloaded checkpoint after splitting to save disk space
+        cache_dir: str, optional
+            Hugging Face download cache. For very large models, place this and
+            ``layer_shards_saving_path`` on a large local SSD.
         """
 
         self.profiling_mode = profiling_mode
@@ -85,14 +80,18 @@ class AirLLMBaseModel:
         self.total_compression_overhead_time = None
         self.hf_quantizer = None
 
-        if compression is not None and not bitsandbytes_installed:
-            raise ImportError('WARNING: bitsandbytes not found. Compression needs bitsandbytes. '
-                              'To use compression, please install bitsandbytes: `pip install bitsandbytes`')
+        if compression is not None:
+            require_bitsandbytes()
 
         self.compression = compression
         self.hf_token = hf_token
 
         self.set_layer_names_dict()
+
+        # Reject an unavailable accelerator before downloading or splitting a checkpoint.
+        self.running_device = device
+        self.device = torch.device(self.running_device)
+        self._validate_running_device()
 
         self.model_local_path, self.checkpoint_path = find_or_create_local_splitted_path(
             model_local_path_or_repo_id,
@@ -100,10 +99,8 @@ class AirLLMBaseModel:
             compression=compression,
             layer_names=self.layer_names_dict,
             hf_token=hf_token,
-            delete_original=delete_original)
-
-        self.running_device = device
-        self.device = torch.device(self.running_device)
+            delete_original=delete_original,
+            cache_dir=cache_dir)
 
         # Prefer transformers' native implementation; only trust the model's bundled remote code when
         # transformers doesn't recognize the architecture. Vendored remote code is frequently pinned
@@ -123,7 +120,9 @@ class AirLLMBaseModel:
         # on deep models (e.g. Qwen3-235B's 94 layers) and produces garbage; bf16's wider range
         # avoids it. Users can still override via dtype=.
         if dtype is None:
-            cfg_dtype = getattr(self.config, "torch_dtype", None)
+            cfg_dtype = getattr(self.config, "dtype", None)
+            if cfg_dtype is None:
+                cfg_dtype = getattr(self.config, "torch_dtype", None)
             if isinstance(cfg_dtype, str):
                 cfg_dtype = getattr(torch, cfg_dtype, None)
             dtype = cfg_dtype if isinstance(cfg_dtype, torch.dtype) else torch.float16
@@ -158,6 +157,20 @@ class AirLLMBaseModel:
 
         self.set_layers_from_layer_names()
         self._install_streaming_hooks()
+
+    def _validate_running_device(self):
+        if self.device.type != "cuda":
+            return
+        if not torch.cuda.is_available():
+            raise EnvironmentError(
+                f"Requested device {self.running_device!r}, but this PyTorch build has no available CUDA/ROCm device. "
+                "Install a GPU-enabled PyTorch build or pass device='cpu' before downloading model weights."
+            )
+        device_index = self.device.index or 0
+        if device_index >= torch.cuda.device_count():
+            raise EnvironmentError(
+                f"Requested device {self.running_device!r}, but only {torch.cuda.device_count()} CUDA/ROCm device(s) exist."
+            )
 
     # ---- customization hooks for subclasses -------------------------------------------------
 
@@ -194,10 +207,11 @@ class AirLLMBaseModel:
                     self.config, attn_implementation="eager", trust_remote_code=self.trust_remote_code)
 
         quantization_config = getattr(self.config, "quantization_config", None)
+        if quantization_config is None:
+            text_config = getattr(self.config, "text_config", None)
+            quantization_config = getattr(text_config, "quantization_config", None)
         if quantization_config is not None:
-            self.hf_quantizer = AutoHfQuantizer.from_config(quantization_config, pre_quantized=True)
-            device_map = self.hf_quantizer.update_device_map(None)
-            self.hf_quantizer.preprocess_model(model=self.model, device_map=device_map)
+            self.prepare_quantized_model(quantization_config)
 
         self.model.eval()
         self.model.tie_weights()
@@ -210,10 +224,14 @@ class AirLLMBaseModel:
             if buffer is not None and buffer.device.type != 'meta':
                 set_module_tensor_to_device(self.model, buffer_name, self.running_device, value=buffer)
 
-        # Force the model to report the running (cuda) device even though its parameters live on
-        # meta between layer executions, so transformers' generation utilities place inputs/cache
-        # tensors on the right device.
+        # Force the model to report the runtime device even though its streamed
+        # parameters live on meta between layer executions.
         self._patch_device_property()
+
+    def prepare_quantized_model(self, quantization_config):
+        self.hf_quantizer = AutoHfQuantizer.from_config(quantization_config, pre_quantized=True)
+        device_map = self.hf_quantizer.update_device_map(None)
+        self.hf_quantizer.preprocess_model(model=self.model, device_map=device_map)
 
     def _patch_device_property(self):
         running_device = torch.device(self.running_device)
@@ -289,7 +307,16 @@ class AirLLMBaseModel:
                 # accompanying weight_scale_inv, producing garbage. Only ordinary high-precision
                 # tensors get cast to the runtime dtype.
                 value = state_dict[param_name]
-                if value.dtype in (torch.float8_e4m3fn, torch.float8_e5m2) or param_name.endswith("_scale_inv"):
+                preserve_quantized_value = (
+                    self.hf_quantizer is not None
+                    and getattr(self.hf_quantizer, "pre_quantized", False)
+                )
+                if (
+                    preserve_quantized_value
+                    or not value.is_floating_point()
+                    or value.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+                    or param_name.endswith(("_scale_inv", ".weight_scale", ".scale"))
+                ):
                     set_module_tensor_to_device(self.model, param_name, self.running_device, value=value)
                 else:
                     set_module_tensor_to_device(self.model, param_name, self.running_device,

--- a/air_llm/airllm/airllm_fp8.py
+++ b/air_llm/airllm/airllm_fp8.py
@@ -1,0 +1,177 @@
+"""AirLLM-native FP8 modules that preserve Hugging Face checkpoint names.
+
+Transformers' fine-grained FP8 loader may fuse a checkpoint's per-expert
+parameters into large 3-D tensors. AirLLM streams the original state dict a
+layer at a time and therefore cannot use that conversion pipeline. These
+modules keep the checkpoint paths unchanged and dequantize only the projection
+currently being executed. The fallback uses ordinary PyTorch operations and is
+intended for correctness on ROCm/Windows where the optional CUDA/Triton FP8
+kernels are unavailable.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def checkpoint_weight_names(checkpoint_path):
+    checkpoint_path = Path(checkpoint_path)
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = checkpoint_path / index_name
+        if index_path.exists():
+            with open(index_path, "r", encoding="utf-8") as f:
+                return set(json.load(f).get("weight_map", {}))
+
+    try:
+        from safetensors import safe_open
+
+        with safe_open(str(checkpoint_path / "model.safetensors"), framework="pt") as f:
+            return set(f.keys())
+    except FileNotFoundError:
+        pass
+
+    torch_path = checkpoint_path / "pytorch_model.bin"
+    if torch_path.exists():
+        return set(torch.load(torch_path, map_location="cpu").keys())
+    return set()
+
+
+def _quantization_value(config, name, default=None):
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+class AirLLMFP8Linear(nn.Module):
+    """Block-scaled FP8 linear that dequantizes one projection at a time."""
+
+    def __init__(self, in_features, out_features, block_size, bias=False, device="meta"):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.block_size = tuple(block_size)
+        self.weight = nn.Parameter(
+            torch.empty(out_features, in_features, dtype=torch.float8_e4m3fn, device=device),
+            requires_grad=False,
+        )
+        scale_shape = (
+            math.ceil(out_features / self.block_size[0]),
+            math.ceil(in_features / self.block_size[1]),
+        )
+        self.weight_scale_inv = nn.Parameter(
+            torch.empty(scale_shape, dtype=torch.float32, device=device),
+            requires_grad=False,
+        )
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, device=device))
+        else:
+            self.register_parameter("bias", None)
+
+    def _dequantized_weight(self, dtype):
+        out_block, in_block = self.block_size
+        scales = self.weight_scale_inv.to(dtype=dtype)
+        scales = scales.repeat_interleave(out_block, dim=0).repeat_interleave(in_block, dim=1)
+        scales = scales[: self.out_features, : self.in_features]
+        return self.weight.to(dtype=dtype) * scales
+
+    def forward(self, inputs):
+        return F.linear(inputs, self._dequantized_weight(inputs.dtype), self.bias)
+
+
+class _AirLLMFP8Expert(nn.Module):
+    def __init__(self, hidden_size, intermediate_size, block_size, device):
+        super().__init__()
+        self.gate_proj = AirLLMFP8Linear(hidden_size, intermediate_size, block_size, device=device)
+        self.up_proj = AirLLMFP8Linear(hidden_size, intermediate_size, block_size, device=device)
+        self.down_proj = AirLLMFP8Linear(intermediate_size, hidden_size, block_size, device=device)
+
+
+class AirLLMFP8Experts(nn.ModuleList):
+    """Per-expert layout matching GLM-5.2's published FP8 state dict."""
+
+    def __init__(self, original, block_size):
+        num_experts = original.num_experts
+        hidden_dim = original.hidden_dim
+        intermediate_dim = original.intermediate_dim
+        device = original.gate_up_proj.device
+        super().__init__(
+            [
+                _AirLLMFP8Expert(hidden_dim, intermediate_dim, block_size, device)
+                for _ in range(num_experts)
+            ]
+        )
+        self.num_experts = num_experts
+        self.hidden_dim = hidden_dim
+        self.intermediate_dim = intermediate_dim
+        self.act_fn = original.act_fn
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final_hidden_states = torch.zeros_like(hidden_states, dtype=torch.float32)
+        with torch.no_grad():
+            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts + 1).permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero(as_tuple=False).view(-1)
+
+        for expert_idx_tensor in expert_hit:
+            expert_idx = int(expert_idx_tensor)
+            if expert_idx == self.num_experts:
+                continue
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            expert = self[expert_idx]
+            current_state = self.act_fn(expert.gate_proj(current_state)) * expert.up_proj(current_state)
+            current_state = expert.down_proj(current_state)
+            current_state = current_state * top_k_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(0, token_idx, current_state.to(final_hidden_states.dtype))
+
+        return final_hidden_states.to(hidden_states.dtype)
+
+
+def _set_module(model, module_name, replacement):
+    parent = model
+    parts = module_name.split(".")
+    for part in parts[:-1]:
+        parent = parent[int(part)] if part.isdigit() else getattr(parent, part)
+    leaf = parts[-1]
+    if leaf.isdigit():
+        parent[int(leaf)] = replacement
+    else:
+        setattr(parent, leaf, replacement)
+
+
+def replace_with_airllm_fp8(model, checkpoint_path, quantization_config):
+    """Replace only modules whose checkpoint weight has an FP8 scale tensor."""
+    weight_names = checkpoint_weight_names(checkpoint_path)
+    block_size = _quantization_value(quantization_config, "weight_block_size", (128, 128))
+    if not weight_names:
+        raise FileNotFoundError(f"Cannot inspect checkpoint weight names under {checkpoint_path}")
+
+    replaced_experts = 0
+    for module_name, module in list(model.named_modules()):
+        expert_scale = f"{module_name}.0.gate_proj.weight_scale_inv"
+        if hasattr(module, "gate_up_proj") and expert_scale in weight_names:
+            _set_module(model, module_name, AirLLMFP8Experts(module, block_size))
+            replaced_experts += 1
+
+    replaced_linears = 0
+    for module_name, module in list(model.named_modules()):
+        if type(module) is not nn.Linear:
+            continue
+        if f"{module_name}.weight_scale_inv" not in weight_names:
+            continue
+        replacement = AirLLMFP8Linear(
+            module.in_features,
+            module.out_features,
+            block_size,
+            bias=module.bias is not None,
+            device=module.weight.device,
+        )
+        _set_module(model, module_name, replacement)
+        replaced_linears += 1
+
+    if replaced_experts == 0 and replaced_linears == 0:
+        raise ValueError("FP8 checkpoint metadata did not match any model modules.")
+    return replaced_experts, replaced_linears

--- a/air_llm/airllm/airllm_glm_moe_dsa.py
+++ b/air_llm/airllm/airllm_glm_moe_dsa.py
@@ -1,0 +1,18 @@
+from .airllm_base import AirLLMBaseModel
+from .airllm_fp8 import replace_with_airllm_fp8
+
+
+def _quantization_method(config):
+    if isinstance(config, dict):
+        return config.get("quant_method")
+    return getattr(config, "quant_method", None)
+
+
+class AirLLMGlmMoeDsa(AirLLMBaseModel):
+    """GLM-5/5.2 loader with an AirLLM-native fine-grained FP8 path."""
+
+    def prepare_quantized_model(self, quantization_config):
+        if _quantization_method(quantization_config) == "fp8":
+            replace_with_airllm_fp8(self.model, self.model_local_path, quantization_config)
+            return
+        super().prepare_quantized_model(quantization_config)

--- a/air_llm/airllm/airllm_kimi_k25.py
+++ b/air_llm/airllm/airllm_kimi_k25.py
@@ -1,0 +1,63 @@
+from .airllm_base import AirLLMBaseModel
+from .airllm_packed import replace_with_airllm_packed_linears
+
+
+class AirLLMKimiK25(AirLLMBaseModel):
+    """Text-only AirLLM streaming for Kimi K2.5/K2.6/K2.7 checkpoints.
+
+    Kimi's multimodal wrapper nests its DeepSeek-style decoder under
+    ``language_model``. The vision tower is intentionally not streamed: it is
+    not needed for text requests, while silently accepting image inputs would
+    execute meta-device weights.
+    """
+
+    def set_layer_names_dict(self):
+        self.layer_names_dict = {
+            "embed": "language_model.model.embed_tokens",
+            "layer_prefix": "language_model.model.layers",
+            "norm": "language_model.model.norm",
+            "lm_head": "language_model.lm_head",
+        }
+
+    def init_model(self):
+        # The official multimodal config forces FlashAttention2 for MoonViT.
+        # AirLLM's Kimi path is text-only and never executes the vision tower,
+        # so requiring flash-attn merely to construct its meta skeleton would
+        # unnecessarily block Windows/ROCm users.
+        vision_config = getattr(self.config, "vision_config", None)
+        if isinstance(vision_config, dict):
+            vision_config["_attn_implementation"] = "eager"
+        elif vision_config is not None:
+            vision_config._attn_implementation = "eager"
+            vision_config._attn_implementation_internal = "eager"
+        super().init_model()
+
+    def prepare_quantized_model(self, quantization_config):
+        super().prepare_quantized_model(quantization_config)
+        quant_method = (
+            quantization_config.get("quant_method")
+            if isinstance(quantization_config, dict)
+            else getattr(quantization_config, "quant_method", None)
+        )
+        if quant_method == "compressed-tensors":
+            replace_with_airllm_packed_linears(self.model)
+            # The custom modules consume the published packed tensors directly.
+            # They must be loaded verbatim and can use normal module.to('meta') cleanup.
+            self.hf_quantizer = None
+
+    @staticmethod
+    def _reject_visual_inputs(kwargs):
+        for name in ("pixel_values", "grid_thws"):
+            if kwargs.get(name) is not None:
+                raise NotImplementedError(
+                    "AirLLM's Kimi K2.5/K2.6/K2.7 path currently supports text-only inference; "
+                    "vision-tower streaming is not implemented."
+                )
+
+    def generate(self, *args, **kwargs):
+        self._reject_visual_inputs(kwargs)
+        return super().generate(*args, **kwargs)
+
+    def forward(self, *args, **kwargs):
+        self._reject_visual_inputs(kwargs)
+        return super().forward(*args, **kwargs)

--- a/air_llm/airllm/airllm_packed.py
+++ b/air_llm/airllm/airllm_packed.py
@@ -1,0 +1,91 @@
+"""Projection-at-a-time execution for compressed-tensors packed weights."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AirLLMPackedLinear(nn.Module):
+    """Keep INT packed checkpoint tensors and dequantize only during one linear call."""
+
+    _STATE_NAMES = (
+        "weight_packed",
+        "weight_scale",
+        "weight_shape",
+        "weight_zero_point",
+        "weight_g_idx",
+        "input_global_scale",
+        "bias",
+    )
+
+    def __init__(self, original):
+        super().__init__()
+        self.in_features = original.in_features
+        self.out_features = original.out_features
+        self.quantization_scheme = original.quantization_scheme
+
+        for name in self._STATE_NAMES:
+            if name in original._parameters and original._parameters[name] is not None:
+                value = original._parameters[name]
+                self.register_parameter(
+                    name,
+                    nn.Parameter(torch.empty_like(value), requires_grad=value.requires_grad),
+                )
+            elif name in original._buffers and original._buffers[name] is not None:
+                self.register_buffer(name, torch.empty_like(original._buffers[name]))
+            else:
+                self.register_parameter(name, None)
+
+    def _compressed_state(self):
+        return {
+            name: getattr(self, name)
+            for name in self._STATE_NAMES
+            if name != "bias" and getattr(self, name, None) is not None
+        }
+
+    def forward(self, inputs):
+        try:
+            from compressed_tensors.compressors.pack_quantized import PackedQuantizationCompressor
+        except ImportError as exc:
+            raise ImportError(
+                "Kimi packed INT weights require compressed-tensors>=0.15.0."
+            ) from exc
+
+        state = PackedQuantizationCompressor.decompress(
+            self._compressed_state(),
+            self.quantization_scheme,
+        )
+        weight = state["weight"].to(dtype=inputs.dtype)
+        bias = self.bias.to(dtype=inputs.dtype) if self.bias is not None else None
+        return F.linear(inputs, weight, bias)
+
+
+def replace_with_airllm_packed_linears(model):
+    """Replace compressed Linear modules and remove whole-model decompression."""
+    replacements = []
+    for module_name, module in model.named_modules():
+        if (
+            isinstance(module, nn.Linear)
+            and hasattr(module, "weight_packed")
+            and hasattr(module, "quantization_scheme")
+        ):
+            replacements.append((module_name, AirLLMPackedLinear(module)))
+
+    for module_name, replacement in replacements:
+        parent = model
+        parts = module_name.split(".")
+        for part in parts[:-1]:
+            parent = parent[int(part)] if part.isdigit() else getattr(parent, part)
+        leaf = parts[-1]
+        if leaf.isdigit():
+            parent[int(leaf)] = replacement
+        else:
+            setattr(parent, leaf, replacement)
+
+    if hasattr(model, "ct_decompress_hook"):
+        model.ct_decompress_hook.remove()
+        delattr(model, "ct_decompress_hook")
+
+    if not replacements:
+        raise ValueError("No compressed-tensors packed Linear modules were found.")
+    return len(replacements)

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -21,6 +21,11 @@ ARCH_OVERRIDES = {
     "BaichuanForCausalLM": "AirLLMBaichuan",
     "BaiChuanForCausalLM": "AirLLMBaichuan",
     "InternLMForCausalLM": "AirLLMInternLM",
+    # Kimi K2.5/2.6/2.7 wrap the text decoder below ``language_model``.
+    "KimiK25ForConditionalGeneration": "AirLLMKimiK25",
+    # GLM-5/5.2 FP8 publishes per-expert tensors that must not be fused by the
+    # normal Transformers loader before AirLLM's layer streaming hooks run.
+    "GlmMoeDsaForCausalLM": "AirLLMGlmMoeDsa",
 }
 
 
@@ -33,11 +38,14 @@ class AutoModel:
 
     @classmethod
     def get_module_class(cls, pretrained_model_name_or_path, *inputs, **kwargs):
-        if 'hf_token' in kwargs:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True,
-                                                token=kwargs['hf_token'])
-        else:
-            config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
+        config_kwargs = {
+            "trust_remote_code": True,
+        }
+        if kwargs.get("hf_token") is not None:
+            config_kwargs["token"] = kwargs["hf_token"]
+        if kwargs.get("cache_dir") is not None:
+            config_kwargs["cache_dir"] = kwargs["cache_dir"]
+        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
 
         architectures = getattr(config, "architectures", None) or []
         arch = architectures[0] if architectures else ""

--- a/air_llm/airllm/preflight.py
+++ b/air_llm/airllm/preflight.py
@@ -1,0 +1,217 @@
+"""Metadata-only compatibility and capacity checks for very large checkpoints."""
+
+import argparse
+import json
+import re
+import shutil
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import huggingface_hub
+
+from .utils import estimated_split_size_bytes
+
+
+KIMI_TEXT_LAYOUT = {
+    "embed": "language_model.model.embed_tokens",
+    "layer_prefix": "language_model.model.layers",
+    "norm": "language_model.model.norm",
+    "lm_head": "language_model.lm_head",
+}
+STANDARD_LAYOUT = {
+    "embed": "model.embed_tokens",
+    "layer_prefix": "model.layers",
+    "norm": "model.norm",
+    "lm_head": "lm_head",
+}
+
+
+@dataclass
+class ModelPreflightReport:
+    model: str
+    architecture: str
+    transformers_version: str | None
+    compatibility: str
+    layer_layout: dict[str, str]
+    layer_count: int
+    tensor_count: int
+    shard_count: int
+    checkpoint_size_bytes: int
+    estimated_split_size_bytes: int
+    average_stream_unit_bytes: int | None
+    offload_free_bytes: int | None = None
+    required_packages: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self):
+        return asdict(self)
+
+
+def _metadata_path(model, hf_token=None, cache_dir=None):
+    local_path = Path(model)
+    if local_path.exists():
+        return local_path
+    return Path(
+        huggingface_hub.snapshot_download(
+            model,
+            token=hf_token,
+            cache_dir=cache_dir,
+            ignore_patterns=["*.safetensors", "*.bin"],
+        )
+    )
+
+
+def _read_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _find_index(model_path):
+    for name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        path = model_path / name
+        if path.exists():
+            return _read_json(path)
+    return None
+
+
+def _layout_for(architecture, weight_names):
+    if architecture == "KimiK25ForConditionalGeneration":
+        return KIMI_TEXT_LAYOUT, "text-only"
+    if any(name.startswith("model.layers.") for name in weight_names):
+        return STANDARD_LAYOUT, "supported"
+    return STANDARD_LAYOUT, "unknown"
+
+
+def inspect_model(model, compression=None, hf_token=None, cache_dir=None, offload_dir=None):
+    """Inspect config and weight index without downloading model weight shards."""
+    model_path = _metadata_path(model, hf_token=hf_token, cache_dir=cache_dir)
+    config = _read_json(model_path / "config.json")
+    architecture = (config.get("architectures") or [""])[0]
+    text_config = config.get("text_config") or {}
+    transformers_version = config.get("transformers_version") or text_config.get("transformers_version")
+
+    index = _find_index(model_path)
+    if index is None:
+        weight_names = []
+        checkpoint_size = sum(
+            path.stat().st_size
+            for pattern in ("*.safetensors", "*.bin")
+            for path in model_path.glob(pattern)
+        )
+        shard_count = 1 if checkpoint_size else 0
+    else:
+        weight_map = index.get("weight_map", {})
+        weight_names = list(weight_map)
+        checkpoint_size = int(index.get("metadata", {}).get("total_size", 0))
+        shard_count = len(set(weight_map.values()))
+
+    layout, compatibility = _layout_for(architecture, weight_names)
+    layer_pattern = re.compile(rf"^{re.escape(layout['layer_prefix'])}\.(\d+)\.")
+    indexed_layer_count = len(
+        {
+            int(match.group(1))
+            for name in weight_names
+            if (match := layer_pattern.match(name)) is not None
+        }
+    )
+    configured_layer_count = text_config.get("num_hidden_layers", config.get("num_hidden_layers"))
+    layer_count = int(configured_layer_count) if configured_layer_count is not None else indexed_layer_count
+    split_size = estimated_split_size_bytes(checkpoint_size, compression)
+    average_stream_unit = split_size // layer_count if layer_count else None
+
+    warnings = []
+    required_packages = []
+    quantization_config = config.get("quantization_config") or text_config.get("quantization_config")
+    if compression is not None and quantization_config is not None:
+        raise ValueError("AirLLM compression cannot be stacked on a pre-quantized checkpoint.")
+    if isinstance(quantization_config, dict) and quantization_config.get("quant_method") == "compressed-tensors":
+        required_packages.append("compressed-tensors>=0.15.0")
+    if architecture == "KimiK25ForConditionalGeneration":
+        required_packages.append("transformers>=4.57.1,<5.0.0")
+    if architecture == "GlmMoeDsaForCausalLM":
+        required_packages.append("transformers>=5.12,<5.13")
+        if isinstance(quantization_config, dict) and quantization_config.get("quant_method") == "fp8":
+            warnings.append(
+                "The portable FP8 path dequantizes one projection at a time; it is compatible but slower than optimized kernels."
+            )
+    if compatibility == "text-only":
+        warnings.append("Kimi K2.5/K2.6/K2.7 support is text-only; vision inputs are rejected.")
+    elif compatibility == "unknown":
+        warnings.append("No supported decoder-layer layout was found in the checkpoint index.")
+    if not checkpoint_size:
+        warnings.append("Checkpoint size is unavailable; disk and stream-unit estimates are incomplete.")
+
+    offload_free = None
+    if offload_dir is not None:
+        offload_path = Path(offload_dir)
+        capacity_path = offload_path
+        while not capacity_path.exists() and capacity_path != capacity_path.parent:
+            capacity_path = capacity_path.parent
+        if not capacity_path.exists():
+            raise FileNotFoundError(f"Offload directory does not exist: {offload_path}")
+        offload_free = shutil.disk_usage(capacity_path).free
+        if split_size > offload_free:
+            warnings.append(
+                f"Offload volume is too small: {split_size} bytes required, {offload_free} bytes free."
+            )
+
+    return ModelPreflightReport(
+        model=model,
+        architecture=architecture,
+        transformers_version=transformers_version,
+        compatibility=compatibility,
+        layer_layout=layout,
+        layer_count=layer_count,
+        tensor_count=len(weight_names),
+        shard_count=shard_count,
+        checkpoint_size_bytes=checkpoint_size,
+        estimated_split_size_bytes=split_size,
+        average_stream_unit_bytes=average_stream_unit,
+        offload_free_bytes=offload_free,
+        required_packages=required_packages,
+        warnings=warnings,
+    )
+
+
+def _gib(value):
+    return "unknown" if value is None else f"{value / (1024 ** 3):.2f} GiB"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Hugging Face repo ID or local checkpoint path")
+    parser.add_argument("--compression", choices=("4bit", "8bit"))
+    parser.add_argument("--cache-dir")
+    parser.add_argument("--offload-dir")
+    parser.add_argument("--hf-token")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = inspect_model(
+        args.model,
+        compression=args.compression,
+        hf_token=args.hf_token,
+        cache_dir=args.cache_dir,
+        offload_dir=args.offload_dir,
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+        return
+
+    print(f"model: {report.model}")
+    print(f"architecture: {report.architecture}")
+    print(f"compatibility: {report.compatibility}")
+    print(f"layers: {report.layer_count}")
+    print(f"checkpoint: {_gib(report.checkpoint_size_bytes)}")
+    print(f"estimated split: {_gib(report.estimated_split_size_bytes)}")
+    print(f"checkpoint/layer size proxy: {_gib(report.average_stream_unit_bytes)}")
+    if report.offload_free_bytes is not None:
+        print(f"offload free: {_gib(report.offload_free_bytes)}")
+    if report.required_packages:
+        print(f"required packages: {', '.join(report.required_packages)}")
+    for warning in report.warnings:
+        print(f"warning: {warning}")
+
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/airllm/server.py
+++ b/air_llm/airllm/server.py
@@ -1,0 +1,148 @@
+"""Minimal non-streaming OpenAI-compatible chat server for AirLLM."""
+
+import argparse
+import threading
+import time
+import uuid
+
+import torch
+
+from .auto_model import AutoModel
+
+
+def _generate_chat(model, messages, max_tokens, temperature, top_p):
+    if not messages or any(not isinstance(message.get("content"), str) for message in messages):
+        raise ValueError("AirLLM's chat server accepts non-empty text-only messages.")
+
+    tokenizer = model.tokenizer
+    prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = tokenizer(prompt, return_tensors="pt", return_attention_mask=True)
+    device = getattr(model, "device", torch.device("cuda:0"))
+    inputs = {name: value.to(device) for name, value in inputs.items()}
+    prompt_tokens = int(inputs["input_ids"].shape[-1])
+
+    generation_kwargs = {
+        "max_new_tokens": max_tokens,
+        "do_sample": temperature > 0,
+        "return_dict_in_generate": True,
+    }
+    if temperature > 0:
+        generation_kwargs.update(temperature=temperature, top_p=top_p)
+
+    with torch.inference_mode():
+        output = model.generate(**inputs, **generation_kwargs)
+    sequence = output.sequences[0]
+    generated = sequence[prompt_tokens:]
+    text = tokenizer.decode(generated, skip_special_tokens=True)
+    return text, prompt_tokens, int(generated.shape[-1])
+
+
+def create_app(model, served_model_name):
+    try:
+        from fastapi import FastAPI, HTTPException
+        from pydantic import BaseModel, Field
+    except ImportError as exc:
+        raise ImportError('Install the server dependencies with `pip install "airllm[server]"`.') from exc
+
+    class ChatMessage(BaseModel):
+        role: str
+        content: str
+
+    class ChatCompletionRequest(BaseModel):
+        model: str | None = None
+        messages: list[ChatMessage]
+        max_tokens: int = Field(default=128, ge=1)
+        temperature: float = Field(default=0.0, ge=0.0)
+        top_p: float = Field(default=1.0, gt=0.0, le=1.0)
+        stream: bool = False
+
+    app = FastAPI(title="AirLLM OpenAI-compatible server")
+    inference_lock = threading.Lock()
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    def models():
+        return {"object": "list", "data": [{"id": served_model_name, "object": "model"}]}
+
+    @app.post("/v1/chat/completions")
+    def chat_completions(request: ChatCompletionRequest):
+        if request.stream:
+            raise HTTPException(status_code=400, detail="Streaming responses are not implemented.")
+        if request.model not in (None, served_model_name):
+            raise HTTPException(status_code=404, detail=f"Unknown model: {request.model}")
+        try:
+            with inference_lock:
+                text, prompt_tokens, completion_tokens = _generate_chat(
+                    model,
+                    [message.model_dump() for message in request.messages],
+                    request.max_tokens,
+                    request.temperature,
+                    request.top_p,
+                )
+        except (ValueError, NotImplementedError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        created = int(time.time())
+        return {
+            "id": f"chatcmpl-{uuid.uuid4().hex}",
+            "object": "chat.completion",
+            "created": created,
+            "model": served_model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+
+    return app
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--cache-dir")
+    parser.add_argument("--offload-dir")
+    parser.add_argument("--compression", choices=("4bit", "8bit"))
+    parser.add_argument("--delete-original", action="store_true")
+    parser.add_argument(
+        "--no-prefetch",
+        action="store_true",
+        help="Load one layer at a time; recommended when two streamed layers would approach system RAM.",
+    )
+    parser.add_argument("--hf-token")
+    args = parser.parse_args(argv)
+
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise ImportError('Install the server dependencies with `pip install "airllm[server]"`.') from exc
+
+    model = AutoModel.from_pretrained(
+        args.model,
+        device=args.device,
+        cache_dir=args.cache_dir,
+        layer_shards_saving_path=args.offload_dir,
+        compression=args.compression,
+        prefetching=not args.no_prefetch,
+        delete_original=args.delete_original,
+        hf_token=args.hf_token,
+    )
+    uvicorn.run(create_app(model, args.model), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -1,4 +1,6 @@
 import gc
+import importlib
+import importlib.util
 import json
 import os
 import ctypes
@@ -25,15 +27,98 @@ from safetensors.torch import load_file, save_file
 from .persist import ModelPersister
 
 
-try:
-    import bitsandbytes as bnb
+bnb = None
 
-    bitsandbytes_installed = True
-except ImportError:
-    bitsandbytes_installed = False
+
+def require_bitsandbytes():
+    """Return a usable bitsandbytes module or fail before model download starts."""
+    global bnb
+    if importlib.util.find_spec("bitsandbytes") is None:
+        raise ImportError("Compression requires bitsandbytes: `pip install bitsandbytes`")
+    if bnb is None:
+        bnb = importlib.import_module("bitsandbytes")
+    native_library = getattr(getattr(bnb, "cextension", None), "lib", None)
+    if native_library is None or type(native_library).__name__ == "ErrorHandlerMockBNBNativeLibrary":
+        raise ImportError(
+            "bitsandbytes is installed, but its native CUDA/ROCm library is unavailable for this platform. "
+            "Use a compatible wheel/build or a checkpoint that is already quantized."
+        )
+    return bnb
+
+
+def bitsandbytes_available():
+    try:
+        require_bitsandbytes()
+        return True
+    except (ImportError, RuntimeError):
+        return False
 
 
 import huggingface_hub
+
+
+COMPRESSION_SIZE_RATIOS = {
+    None: 1.0,
+    "8bit": 0.5,
+    # NF4 packs two values per byte and stores one fp32 absmax per 64 values.
+    "4bit": 0.2813,
+}
+
+
+def estimated_split_size_bytes(model_size_bytes, compression=None):
+    """Estimate the final layer-shard footprint for an AirLLM compression mode."""
+    if compression not in COMPRESSION_SIZE_RATIOS:
+        raise ValueError(f"Unsupported compression mode: {compression!r}")
+    return int(model_size_bytes * COMPRESSION_SIZE_RATIOS[compression])
+
+
+def checkpoint_total_size_bytes(checkpoint_path):
+    """Return checkpoint weight size, preferring index metadata when available.
+
+    Hugging Face downloads the index before the large weight files. Reading
+    ``metadata.total_size`` lets us reject an undersized offload volume before
+    hundreds of gigabytes have been downloaded.
+    """
+    checkpoint_path = Path(checkpoint_path)
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = checkpoint_path / index_name
+        if index_path.exists():
+            with open(index_path, "rb") as f:
+                metadata = json.load(f).get("metadata", {})
+            total_size = metadata.get("total_size")
+            if total_size is not None:
+                return int(total_size)
+
+    total = 0
+    for pattern in ("*.safetensors", "*.bin"):
+        for model_file in checkpoint_path.glob(pattern):
+            total += model_file.stat().st_size
+    return total
+
+
+def checkpoint_quantization_method(checkpoint_path):
+    config_path = Path(checkpoint_path) / "config.json"
+    if not config_path.exists():
+        return None
+    with open(config_path, "rb") as f:
+        config = json.load(f)
+    text_config = config.get("text_config") or {}
+    quantization_config = config.get("quantization_config") or text_config.get("quantization_config")
+    if isinstance(quantization_config, dict):
+        return quantization_config.get("quant_method") or quantization_config.get("format") or "pre-quantized"
+    return None
+
+
+def configured_decoder_layer_count(checkpoint_path):
+    """Read the inference decoder count, excluding auxiliary MTP layers."""
+    config_path = Path(checkpoint_path) / "config.json"
+    if not config_path.exists():
+        return None
+    with open(config_path, "rb") as f:
+        config = json.load(f)
+    text_config = config.get("text_config") or {}
+    value = text_config.get("num_hidden_layers", config.get("num_hidden_layers"))
+    return int(value) if value is not None else None
 
 
 # replacement for bnb quantstat.as_dict(True), until the bug is fixed....
@@ -63,7 +148,8 @@ def save_quant_state_to_dict(self, packed=True):
 
     qs_packed_dict = {k: v for k, v in qs_dict.items() if isinstance(v, torch.Tensor)}
     non_tensor_dict = {k: v for k, v in qs_dict.items() if not isinstance(v, torch.Tensor)}
-    qs_packed_dict["quant_state." + "bitsandbytes__" + self.quant_type] = bnb.utils.pack_dict_to_tensor(non_tensor_dict)
+    bnb_module = require_bitsandbytes()
+    qs_packed_dict["quant_state." + "bitsandbytes__" + self.quant_type] = bnb_module.utils.pack_dict_to_tensor(non_tensor_dict)
     return qs_packed_dict
 
 
@@ -85,16 +171,18 @@ def clean_memory():
 def uncompress_layer_state_dict(layer_state_dict):
     uncompressed_layer_state_dict = None
     if any(['4bit' in k for k in layer_state_dict.keys()]):
+        bnb_module = require_bitsandbytes()
         uncompressed_layer_state_dict = {}
         for k, v in layer_state_dict.items():
             if '4bit' not in k:
                 quant_state_dict = {kk[len(k):]: kv for kk, kv in layer_state_dict.items() if kk.startswith(k) and k != kk}
-                quant_state = bnb.functional.QuantState.from_dict(qs_dict=quant_state_dict, device="cuda")
+                quant_state = bnb_module.functional.QuantState.from_dict(qs_dict=quant_state_dict, device="cuda")
 
-                dqv = bnb.functional.dequantize_nf4(v.cuda(), quant_state)
+                dqv = bnb_module.functional.dequantize_nf4(v.cuda(), quant_state)
                 uncompressed_layer_state_dict[k] = dqv
         del layer_state_dict
     elif any(['8bit' in k for k in layer_state_dict.keys()]):
+        bnb_module = require_bitsandbytes()
         uncompressed_layer_state_dict = {}
         for k, v in layer_state_dict.items():
             if '8bit' not in k:
@@ -102,8 +190,8 @@ def uncompress_layer_state_dict(layer_state_dict):
                 absmax = layer_state_dict[k + ".8bit.absmax"]
                 code = layer_state_dict[k + ".8bit.code"]
 
-                dqv = bnb.functional.dequantize_blockwise(v.cuda(),
-                                                          bnb.functional.QuantState(absmax=absmax.cuda(),
+                dqv = bnb_module.functional.dequantize_blockwise(v.cuda(),
+                                                          bnb_module.functional.QuantState(absmax=absmax.cuda(),
                                                                                     code=code.cuda(),
                                                                                     blocksize=2048,
                                                                                     dtype=torch.float16))
@@ -132,41 +220,43 @@ def load_layer(local_path, layer_name, profiling=False):
 
 
 def check_space(checkpoint_path, layer_shards_saving_path=None, compression=None, splitted_model_dir_name='splitted_model'):
-    total_shard_files_size_bytes = 0
-    for model_shard_file in glob(str(checkpoint_path / '*')):
-        total_shard_files_size_bytes += os.path.getsize(model_shard_file)
+    checkpoint_path = Path(checkpoint_path)
+    total_shard_files_size_bytes = checkpoint_total_size_bytes(checkpoint_path)
+    required_split_size_bytes = estimated_split_size_bytes(total_shard_files_size_bytes, compression)
 
     total_saved_split_files_size_bytes = 0
     if layer_shards_saving_path is not None:
         for saved_split_file in glob(str(Path(layer_shards_saving_path) / splitted_model_dir_name / '*')):
             total_saved_split_files_size_bytes += os.path.getsize(saved_split_file)
 
-    if compression == '4bit':
-        total_shard_files_size_bytes = int(total_shard_files_size_bytes / 0.2813)
-    elif compression == '8bit':
-        total_shard_files_size_bytes = total_shard_files_size_bytes // 2
+    capacity_path = checkpoint_path if layer_shards_saving_path is None else Path(layer_shards_saving_path)
+    while not capacity_path.exists() and capacity_path != capacity_path.parent:
+        capacity_path = capacity_path.parent
+    if not capacity_path.exists():
+        raise FileNotFoundError(f"Offload volume does not exist: {layer_shards_saving_path}")
+    total, used, free = shutil.disk_usage(capacity_path)
 
-    total, used, free = shutil.disk_usage(checkpoint_path if layer_shards_saving_path is None else layer_shards_saving_path)
-
-    if free + total_saved_split_files_size_bytes < total_shard_files_size_bytes:
+    if free + total_saved_split_files_size_bytes < required_split_size_bytes:
         raise NotEnoughSpaceException(f"Not enough space. Free space under {checkpoint_path if layer_shards_saving_path is None else layer_shards_saving_path}:"  \
-                                      f" {free / 1024 / 1024 / 1024:.02f}GB. Model total size: {total_shard_files_size_bytes / 1024 / 1024 / 1024:.02f}GB. " \
+                                      f" {free / 1024 / 1024 / 1024:.02f}GB. Estimated split size: {required_split_size_bytes / 1024 / 1024 / 1024:.02f}GB. " \
                                       f"existing space under {checkpoint_path if layer_shards_saving_path is None else layer_shards_saving_path} assuming can reuse: {total_saved_split_files_size_bytes/ 1024 / 1024 / 1024:.02f}GB. "
                                       )
 
 def compress_layer_state_dict(layer_state_dict, compression=None):
     compressed_layer_state_dict = None
     if compression == '4bit':
+        bnb_module = require_bitsandbytes()
         compressed_layer_state_dict = {}
         for k, v in layer_state_dict.items():
-            v_quant, quant_state = bnb.functional.quantize_nf4(v.cuda(), blocksize=64)
+            v_quant, quant_state = bnb_module.functional.quantize_nf4(v.cuda(), blocksize=64)
             compressed_layer_state_dict[k] = v_quant
             for quant_state_k, quant_state_v in save_quant_state_to_dict(quant_state).items():
                 compressed_layer_state_dict[k + ".4bit." + quant_state_k] = quant_state_v
     elif compression == '8bit':
+        bnb_module = require_bitsandbytes()
         compressed_layer_state_dict = {}
         for k, v in layer_state_dict.items():
-            v_quant, quant_state = bnb.functional.quantize_blockwise(v.cuda(), blocksize=2048)
+            v_quant, quant_state = bnb_module.functional.quantize_blockwise(v.cuda(), blocksize=2048)
             absmax = quant_state.absmax.clone().contiguous()
             code = quant_state.code.clone().contiguous()
             compressed_layer_state_dict[k] = v_quant
@@ -176,23 +266,30 @@ def compress_layer_state_dict(layer_state_dict, compression=None):
     return compressed_layer_state_dict if compressed_layer_state_dict is not None else layer_state_dict
 
 def remove_real_and_linked_file(to_delete):
+    targetpath = None
     if (os.path.realpath(to_delete) != to_delete):
         targetpath = os.path.realpath(to_delete)
 
     os.remove(to_delete)
-    if (targetpath):
+    if targetpath and os.path.exists(targetpath):
          os.remove(targetpath)
 
 
 
 def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitted_model_dir_name='splitted_model',
-                          compression=None, layer_names=None, delete_original=False, repo_id=None, hf_token=None):
+                          compression=None, layer_names=None, delete_original=False, repo_id=None, hf_token=None,
+                          cache_dir=None):
     """
     Save the all layers of a model sharded checkpoint using safetensors.
     """
 
     if compression is not None:
-        assert bitsandbytes_installed, f"when using compression bitsandbytes has to be installed."
+        require_bitsandbytes()
+        quantization_method = checkpoint_quantization_method(checkpoint_path)
+        if quantization_method is not None:
+            raise ValueError(
+                f"AirLLM compression cannot be stacked on a pre-quantized checkpoint ({quantization_method})."
+            )
         splitted_model_dir_name = splitted_model_dir_name + "." + compression
 
     checkpoint_path = Path(checkpoint_path)
@@ -231,7 +328,10 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
             f"No model weights found under {checkpoint_path}. Expected one of: "
             f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
 
-    if layer_names is None:
+    configured_layers = configured_decoder_layer_count(checkpoint_path)
+    if configured_layers is not None:
+        n_layers = configured_layers
+    elif layer_names is None:
         n_layers = len(set([int(k.split('.')[2]) for k in index.keys() if 'model.layers' in k]))
     else:
         n_layers = len(set([int(k[len(layer_names['layer_prefix']):].split('.')[1]) for k in index.keys() if layer_names['layer_prefix'] in k]))
@@ -269,8 +369,11 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         else:
             print(f"some layer splits found, some are not, re-save all layers in case there's some corruptions.")
 
-    if not delete_original:
-        check_space(checkpoint_path, layer_shards_saving_path, compression, splitted_model_dir_name=splitted_model_dir_name)
+    saving_path.mkdir(parents=True, exist_ok=True)
+
+    # The split itself must fit even when original checkpoint shards are deleted as we go.
+    check_space(checkpoint_path, layer_shards_saving_path, compression,
+                splitted_model_dir_name=splitted_model_dir_name)
 
 
     shard = 0
@@ -288,10 +391,6 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 shard_num_to_file[int(parts[1])] = v
             except ValueError:
                 pass
-
-    if not os.path.exists(saving_path):
-        #os.makedirs(saving_path)
-        saving_path.mkdir(parents=True, exist_ok=True)
 
     single_modelfile = None
 
@@ -321,7 +420,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 if not os.path.exists(to_load):
                     assert repo_id is not None
                     huggingface_hub.snapshot_download(repo_id, allow_patterns=os.path.basename(to_load),
-                                                    token=hf_token)
+                                                    token=hf_token, cache_dir=cache_dir)
 
                 if not safetensors_format:
                     state_dict.update(torch.load(to_load, map_location='cpu'))
@@ -336,7 +435,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
             if not os.path.exists(to_load):
                 assert repo_id is not None
                 huggingface_hub.snapshot_download(repo_id, allow_patterns=os.path.basename(to_load),
-                                                token=hf_token)
+                                                token=hf_token, cache_dir=cache_dir)
             if not safetensors_format:
                 state_dict.update(torch.load(to_load, map_location='cpu'))
             else:
@@ -366,11 +465,20 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         to_delete = checkpoint_path / single_modelfile
         print(f"deleting original file: {to_delete}")
         remove_real_and_linked_file(to_delete)
+    elif delete_original:
+        # The rolling deletion above removes a shard only when the next shard is
+        # opened. Remove the final shard (and any non-sequential leftovers) after
+        # every requested inference layer has been persisted successfully.
+        for checkpoint_file in set(index.values()):
+            to_delete = checkpoint_path / checkpoint_file
+            if to_delete.exists():
+                print(f"deleting original file: {to_delete}")
+                remove_real_and_linked_file(to_delete)
 
     return str(saving_path)
 
 def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards_saving_path=None, compression=None,
-                                       layer_names=None, hf_token=None, delete_original=False):
+                                       layer_names=None, hf_token=None, delete_original=False, cache_dir=None):
     """
     find the model's local cache path, download the cache if not exists, then split and save the model.
 
@@ -391,13 +499,22 @@ def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards
         setting to '4bit' or '8bit' to enable compression from 16 bits to 4 bits/8 bits which speeed up 4x or 2x inference time with a tiny accuracy loss.
     hf_token: str, optional
         huggingface api token could be provided, by default None
+    cache_dir: str, optional
+        Hugging Face download cache. Set this together with
+        ``layer_shards_saving_path`` when the system drive is too small.
     """
 
     # try local model path, if the model exist split and save there
     if os.path.exists(model_local_path_or_repo_id):
-        if os.path.exists(Path(model_local_path_or_repo_id) / 'pytorch_model.bin.index.json') or \
-           os.path.exists(Path(model_local_path_or_repo_id) / 'model.safetensors.index.json'):
-            print(f"found index file...")
+        local_model_path = Path(model_local_path_or_repo_id)
+        local_weight_files = (
+            'pytorch_model.bin.index.json',
+            'model.safetensors.index.json',
+            'pytorch_model.bin',
+            'model.safetensors',
+        )
+        if any((local_model_path / filename).exists() for filename in local_weight_files):
+            print(f"found local model weights...")
             return Path(model_local_path_or_repo_id), split_and_save_layers(model_local_path_or_repo_id, layer_shards_saving_path,
                                                                             compression=compression, layer_names=layer_names, delete_original=delete_original)
         else:
@@ -408,6 +525,7 @@ def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards
     # First grab everything except the (potentially huge) weight files. For multi-shard models the
     # index.json tells us the structure and we stream each shard on demand during splitting.
     hf_cache_path = huggingface_hub.snapshot_download(model_local_path_or_repo_id, token=hf_token,
+        cache_dir=cache_dir,
         #allow_patterns= ["model.safetensors.index.json", 'pytorch_model.bin.index.json'],
         ignore_patterns=['*.safetensors', '*.bin'])
 
@@ -418,6 +536,7 @@ def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards
     if not has_index:
         hf_cache_path = huggingface_hub.snapshot_download(
             model_local_path_or_repo_id, token=hf_token,
+            cache_dir=cache_dir,
             allow_patterns=['model.safetensors', 'pytorch_model.bin'])
 
 
@@ -442,4 +561,5 @@ def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards
     # if splitted_model subdir exists under cache use it, otherwise split and save
     return Path(hf_cache_path), split_and_save_layers(hf_cache_path, layer_shards_saving_path,
                                                       compression=compression, layer_names=layer_names,
-                                                      delete_original=delete_original, repo_id=model_local_path_or_repo_id, hf_token=hf_token)
+                                                      delete_original=delete_original, repo_id=model_local_path_or_repo_id,
+                                                      hf_token=hf_token, cache_dir=cache_dir)

--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -37,6 +37,18 @@ setuptools.setup(
         'sentencepiece',
         # 'bitsandbytes' is optional (used only for --compression); we fall back gracefully when absent.
     ],
+    extras_require={
+        'compression': ['bitsandbytes'],
+        'glm52': ['transformers>=5.12,<5.13'],
+        'kimi': ['compressed-tensors>=0.15.0', 'transformers>=4.57.1,<5.0.0'],
+        'server': ['fastapi>=0.115', 'uvicorn>=0.30'],
+    },
+    entry_points={
+        'console_scripts': [
+            'airllm-preflight=airllm.preflight:main',
+            'airllm-serve=airllm.server:main',
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/air_llm/tests/test_automodel.py
+++ b/air_llm/tests/test_automodel.py
@@ -1,31 +1,45 @@
-import sys
 import unittest
-
-#sys.path.insert(0, '../airllm')
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from ..airllm.auto_model import AutoModel
 
 
-
 class TestAutoModel(unittest.TestCase):
-    def setUp(self):
-        pass
-    def tearDown(self):
-        pass
-
-    def test_auto_model_should_return_correct_model(self):
-        mapping_dict = {
-            'garage-bAInd/Platypus2-7B': 'AirLLMLlama2',
-            'Qwen/Qwen-7B': 'AirLLMQWen',
-            'internlm/internlm-chat-7b': 'AirLLMInternLM',
-            'THUDM/chatglm3-6b-base': 'AirLLMChatGLM',
-            'baichuan-inc/Baichuan2-7B-Base': 'AirLLMBaichuan',
-            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMMistral',
-            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMMixtral'
+    @patch("airllm.auto_model.AutoConfig.from_pretrained")
+    def test_custom_architectures_use_dedicated_streaming_layouts(self, from_pretrained):
+        cases = {
+            "ChatGLMForConditionalGeneration": "AirLLMChatGLM",
+            "QWenLMHeadModel": "AirLLMQWen",
+            "BaichuanForCausalLM": "AirLLMBaichuan",
+            "InternLMForCausalLM": "AirLLMInternLM",
+            "KimiK25ForConditionalGeneration": "AirLLMKimiK25",
+            "GlmMoeDsaForCausalLM": "AirLLMGlmMoeDsa",
         }
+        for architecture, expected in cases.items():
+            with self.subTest(architecture=architecture):
+                from_pretrained.return_value = SimpleNamespace(architectures=[architecture])
+                module, class_name = AutoModel.get_module_class("local-model")
+                self.assertEqual(module, "airllm")
+                self.assertEqual(class_name, expected)
 
+    @patch("airllm.auto_model.AutoConfig.from_pretrained")
+    def test_standard_and_new_architectures_use_generic_streaming(self, from_pretrained):
+        for architecture in ("LlamaForCausalLM", "UnknownForCausalLM"):
+            with self.subTest(architecture=architecture):
+                from_pretrained.return_value = SimpleNamespace(architectures=[architecture])
+                self.assertEqual(
+                    AutoModel.get_module_class("local-model"),
+                    ("airllm", "AirLLMBaseModel"),
+                )
 
-        for k,v in mapping_dict.items():
-            module, cls = AutoModel.get_module_class(k)
-            self.assertEqual(cls, v, f"expecting {v}")
-
+    @patch("airllm.auto_model.AutoConfig.from_pretrained")
+    def test_config_probe_uses_requested_cache(self, from_pretrained):
+        from_pretrained.return_value = SimpleNamespace(architectures=["LlamaForCausalLM"])
+        AutoModel.get_module_class("repo/model", cache_dir="D:/model-cache", hf_token="token")
+        from_pretrained.assert_called_once_with(
+            "repo/model",
+            trust_remote_code=True,
+            cache_dir="D:/model-cache",
+            token="token",
+        )

--- a/air_llm/tests/test_compression.py
+++ b/air_llm/tests/test_compression.py
@@ -5,10 +5,15 @@ import torch
 sys.path.insert(0, '../airllm')
 
 from airllm import compress_layer_state_dict, uncompress_layer_state_dict
+from airllm.utils import bitsandbytes_available
 
 
 
 
+@unittest.skipUnless(
+    torch.cuda.is_available() and bitsandbytes_available(),
+    "compression round-trip requires a CUDA/ROCm device and bitsandbytes",
+)
 class TestCompression(unittest.TestCase):
     def setUp(self):
         pass

--- a/air_llm/tests/test_device_validation.py
+++ b/air_llm/tests/test_device_validation.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from ..airllm.airllm_base import AirLLMBaseModel
+
+
+class TestDeviceValidation(unittest.TestCase):
+    def test_cpu_device_is_always_allowed(self):
+        model = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        model.running_device = "cpu"
+        model.device = torch.device("cpu")
+        model._validate_running_device()
+
+    @patch("torch.cuda.is_available", return_value=False)
+    def test_unavailable_gpu_fails_before_checkpoint_work(self, is_available):
+        model = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        model.running_device = "cuda:0"
+        model.device = torch.device("cuda:0")
+        with self.assertRaises(EnvironmentError):
+            model._validate_running_device()

--- a/air_llm/tests/test_glm_fp8.py
+++ b/air_llm/tests/test_glm_fp8.py
@@ -1,0 +1,93 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from ..airllm.airllm_fp8 import AirLLMFP8Experts, AirLLMFP8Linear, replace_with_airllm_fp8
+
+
+class _OriginalExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts = 2
+        self.hidden_dim = 4
+        self.intermediate_dim = 4
+        self.gate_up_proj = nn.Parameter(torch.empty(2, 8, 4, device="meta"))
+        self.down_proj = nn.Parameter(torch.empty(2, 4, 4, device="meta"))
+        self.act_fn = torch.nn.functional.silu
+
+
+class _TinyLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4, bias=False, device="meta")
+        self.experts = _OriginalExperts()
+
+
+class _TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = _TinyLayer()
+
+
+class TestGlmFp8(unittest.TestCase):
+    def test_block_scaled_linear_matches_explicit_dequantization(self):
+        module = AirLLMFP8Linear(4, 4, (2, 2), device="cpu")
+        weight = torch.tensor(
+            [[1, 2, 3, 4], [2, 1, 0, -1], [1, -1, 2, -2], [4, 3, 2, 1]],
+            dtype=torch.float32,
+        ).to(torch.float8_e4m3fn)
+        scales = torch.tensor([[0.5, 1.5], [2.0, 0.25]])
+        module.weight.data.copy_(weight)
+        module.weight_scale_inv.data.copy_(scales)
+        inputs = torch.tensor([[1.0, 2.0, -1.0, 0.5]])
+
+        expanded = scales.repeat_interleave(2, 0).repeat_interleave(2, 1)
+        expected = torch.nn.functional.linear(inputs, weight.float() * expanded)
+        torch.testing.assert_close(module(inputs), expected)
+
+    def test_expert_parameter_names_match_checkpoint_layout(self):
+        experts = AirLLMFP8Experts(_OriginalExperts(), (2, 2))
+        names = set(experts.state_dict())
+        self.assertIn("0.gate_proj.weight", names)
+        self.assertIn("0.gate_proj.weight_scale_inv", names)
+        self.assertIn("1.down_proj.weight", names)
+        self.assertNotIn("experts.0.gate_proj.weight", names)
+
+    def test_replacement_uses_only_scaled_checkpoint_weights(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            weight_names = {
+                "layer.proj.weight": "model.safetensors",
+                "layer.proj.weight_scale_inv": "model.safetensors",
+                "layer.experts.0.gate_proj.weight": "model.safetensors",
+                "layer.experts.0.gate_proj.weight_scale_inv": "model.safetensors",
+            }
+            (root / "model.safetensors.index.json").write_text(
+                json.dumps({"weight_map": weight_names}), encoding="utf-8"
+            )
+            model = _TinyModel()
+            expert_count, linear_count = replace_with_airllm_fp8(
+                model,
+                root,
+                {"weight_block_size": [2, 2]},
+            )
+
+        self.assertEqual(expert_count, 1)
+        self.assertEqual(linear_count, 1)
+        self.assertIsInstance(model.layer.proj, AirLLMFP8Linear)
+        self.assertIsInstance(model.layer.experts, AirLLMFP8Experts)
+        self.assertIn("layer.experts.0.gate_proj.weight", model.state_dict())
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA/ROCm device")
+    def test_block_scaled_linear_runs_on_gpu(self):
+        module = AirLLMFP8Linear(128, 128, (128, 128), device="cuda")
+        module.weight.data.copy_(torch.randn(128, 128, device="cuda").to(torch.float8_e4m3fn))
+        module.weight_scale_inv.data.fill_(0.125)
+        inputs = torch.randn(2, 128, device="cuda", dtype=torch.bfloat16)
+        output = module(inputs)
+        self.assertEqual(output.shape, (2, 128))
+        self.assertTrue(torch.isfinite(output).all())

--- a/air_llm/tests/test_kimi_k25.py
+++ b/air_llm/tests/test_kimi_k25.py
@@ -1,0 +1,38 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ..airllm.airllm_base import AirLLMBaseModel
+from ..airllm.airllm_kimi_k25 import AirLLMKimiK25
+
+
+class TestKimiK25(unittest.TestCase):
+    def test_layer_layout(self):
+        model = AirLLMKimiK25.__new__(AirLLMKimiK25)
+        model.set_layer_names_dict()
+        self.assertEqual(model.layer_names_dict["embed"], "language_model.model.embed_tokens")
+        self.assertEqual(model.layer_names_dict["layer_prefix"], "language_model.model.layers")
+        self.assertEqual(model.layer_names_dict["norm"], "language_model.model.norm")
+        self.assertEqual(model.layer_names_dict["lm_head"], "language_model.lm_head")
+
+    def test_visual_inputs_are_rejected(self):
+        with self.assertRaises(NotImplementedError):
+            AirLLMKimiK25._reject_visual_inputs({"pixel_values": object()})
+
+        AirLLMKimiK25._reject_visual_inputs({"pixel_values": None, "grid_thws": None})
+
+    @patch.object(AirLLMBaseModel, "init_model")
+    def test_vision_flash_attention_is_disabled_for_text_only_loader(self, base_init):
+        model = AirLLMKimiK25.__new__(AirLLMKimiK25)
+        model.config = SimpleNamespace(
+            vision_config=SimpleNamespace(
+                _attn_implementation="flash_attention_2",
+                _attn_implementation_internal="flash_attention_2",
+            )
+        )
+
+        model.init_model()
+
+        self.assertEqual(model.config.vision_config._attn_implementation, "eager")
+        self.assertEqual(model.config.vision_config._attn_implementation_internal, "eager")
+        base_init.assert_called_once_with()

--- a/air_llm/tests/test_notebooks/test_sealllm.ipynb
+++ b/air_llm/tests/test_notebooks/test_sealllm.ipynb
@@ -3243,7 +3243,7 @@
         "\n",
         "MAX_LENGTH = 128\n",
         "# could use hugging face model repo id:\n",
-        "model = AutoModel.from_pretrained(\"SeaLLMs/SeaLLM-7B-Chat\", hf_token='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')\n",
+        "model = AutoModel.from_pretrained(\"SeaLLMs/SeaLLM-7B-Chat\", hf_token='YOUR_HF_TOKEN')\n",
         "\n",
         "input_text = [\n",
         "        'I like',\n",

--- a/air_llm/tests/test_packed_linear.py
+++ b/air_llm/tests/test_packed_linear.py
@@ -1,0 +1,115 @@
+import importlib.util
+import unittest
+
+import torch
+import torch.nn as nn
+
+from ..airllm.airllm_packed import AirLLMPackedLinear, replace_with_airllm_packed_linears
+
+
+class _PackedSkeleton(nn.Linear):
+    def __init__(self):
+        super().__init__(32, 32, bias=False, device="meta")
+        del self._parameters["weight"]
+        self.weight_packed = nn.Parameter(
+            torch.empty(32, 4, dtype=torch.int32, device="meta"), requires_grad=False
+        )
+        self.weight_scale = nn.Parameter(
+            torch.empty(32, 1, dtype=torch.float32, device="meta"), requires_grad=False
+        )
+        self.weight_shape = nn.Parameter(
+            torch.empty(2, dtype=torch.int64, device="meta"), requires_grad=False
+        )
+        self.quantization_scheme = object()
+
+
+class _Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = _PackedSkeleton()
+        self.ct_decompress_hook = self.register_forward_pre_hook(lambda model, args: None)
+
+
+class TestPackedLinear(unittest.TestCase):
+    def test_replacement_preserves_checkpoint_state_names(self):
+        model = _Model()
+        count = replace_with_airllm_packed_linears(model)
+
+        self.assertEqual(count, 1)
+        self.assertIsInstance(model.proj, AirLLMPackedLinear)
+        self.assertFalse(hasattr(model, "ct_decompress_hook"))
+        self.assertEqual(
+            set(model.proj.state_dict()),
+            {"weight_packed", "weight_scale", "weight_shape"},
+        )
+
+    @unittest.skipUnless(importlib.util.find_spec("compressed_tensors"), "requires compressed-tensors")
+    def test_packed_projection_matches_explicit_decompression(self):
+        from compressed_tensors.compressors.pack_quantized import PackedQuantizationCompressor
+        from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+
+        scheme = QuantizationScheme(
+            targets=["Linear"],
+            weights=QuantizationArgs(
+                num_bits=4,
+                type="int",
+                symmetric=True,
+                strategy="group",
+                group_size=32,
+            ),
+        )
+        weight = torch.randint(-7, 8, (32, 32), dtype=torch.int8).float()
+        scale = torch.ones(32, 1)
+        compressed = PackedQuantizationCompressor.compress(
+            {"weight": weight, "weight_scale": scale}, scheme
+        )
+
+        original = _PackedSkeleton()
+        original.quantization_scheme = scheme
+        module = AirLLMPackedLinear(original).to_empty(device="cpu")
+        module.weight_packed.data.copy_(compressed["weight_packed"])
+        module.weight_scale.data.copy_(compressed["weight_scale"])
+        module.weight_shape.data.copy_(compressed["weight_shape"])
+        inputs = torch.randn(2, 32)
+
+        explicit = PackedQuantizationCompressor.decompress(compressed, scheme)["weight"]
+        expected = torch.nn.functional.linear(inputs, explicit)
+        torch.testing.assert_close(module(inputs), expected)
+
+    @unittest.skipUnless(
+        importlib.util.find_spec("compressed_tensors") and torch.cuda.is_available(),
+        "requires compressed-tensors and a CUDA/ROCm device",
+    )
+    def test_packed_projection_runs_on_gpu(self):
+        from compressed_tensors.compressors.pack_quantized import PackedQuantizationCompressor
+        from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+
+        scheme = QuantizationScheme(
+            targets=["Linear"],
+            weights=QuantizationArgs(
+                num_bits=4,
+                type="int",
+                symmetric=True,
+                strategy="group",
+                group_size=32,
+            ),
+        )
+        compressed = PackedQuantizationCompressor.compress(
+            {
+                "weight": torch.randint(-7, 8, (32, 32), dtype=torch.int8).float(),
+                "weight_scale": torch.ones(32, 1),
+            },
+            scheme,
+        )
+        original = _PackedSkeleton()
+        original.quantization_scheme = scheme
+        module = AirLLMPackedLinear(original).to_empty(device="cuda")
+        for name, value in compressed.items():
+            getattr(module, name).data.copy_(value.to("cuda"))
+        inputs = torch.randn(2, 32, device="cuda", dtype=torch.bfloat16)
+
+        explicit = PackedQuantizationCompressor.decompress(
+            {name: value.to("cuda") for name, value in compressed.items()}, scheme
+        )["weight"].to(torch.bfloat16)
+        expected = torch.nn.functional.linear(inputs, explicit)
+        torch.testing.assert_close(module(inputs), expected)

--- a/air_llm/tests/test_preflight.py
+++ b/air_llm/tests/test_preflight.py
@@ -1,0 +1,172 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+from ..airllm.preflight import inspect_model
+from ..airllm.utils import checkpoint_total_size_bytes, estimated_split_size_bytes, split_and_save_layers
+
+
+class TestPreflight(unittest.TestCase):
+    def _write_model_metadata(self, root, architecture, prefix, total_size=10_000, num_hidden_layers=None):
+        config = {
+            "architectures": [architecture],
+            "transformers_version": "5.12.0",
+        }
+        if num_hidden_layers is not None:
+            config["num_hidden_layers"] = num_hidden_layers
+        weight_map = {
+            f"{prefix}.0.self_attn.q_proj.weight": "model-00001-of-00002.safetensors",
+            f"{prefix}.1.self_attn.q_proj.weight": "model-00002-of-00002.safetensors",
+        }
+        (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (root / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": total_size}, "weight_map": weight_map}),
+            encoding="utf-8",
+        )
+
+    def test_glm_standard_layout_and_size_estimates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_model_metadata(root, "GlmMoeDsaForCausalLM", "model.layers")
+            report = inspect_model(str(root), compression="4bit", offload_dir=root)
+
+        self.assertEqual(report.compatibility, "supported")
+        self.assertEqual(report.layer_count, 2)
+        self.assertEqual(report.checkpoint_size_bytes, 10_000)
+        self.assertEqual(report.estimated_split_size_bytes, 2_813)
+        self.assertIn("transformers>=5.12,<5.13", report.required_packages)
+
+    def test_kimi_uses_nested_text_layout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_model_metadata(
+                root,
+                "KimiK25ForConditionalGeneration",
+                "language_model.model.layers",
+            )
+            report = inspect_model(str(root))
+
+        self.assertEqual(report.compatibility, "text-only")
+        self.assertEqual(report.layer_layout["lm_head"], "language_model.lm_head")
+        self.assertEqual(report.layer_count, 2)
+        self.assertTrue(any("text-only" in warning for warning in report.warnings))
+        self.assertIn("transformers>=4.57.1,<5.0.0", report.required_packages)
+
+    def test_checkpoint_size_prefers_index_metadata(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_model_metadata(root, "LlamaForCausalLM", "model.layers", total_size=123_456)
+            self.assertEqual(checkpoint_total_size_bytes(root), 123_456)
+
+    def test_configured_layer_count_excludes_auxiliary_index_layers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_model_metadata(
+                root,
+                "GlmMoeDsaForCausalLM",
+                "model.layers",
+                num_hidden_layers=1,
+            )
+            report = inspect_model(str(root))
+
+        self.assertEqual(report.layer_count, 1)
+
+    def test_split_excludes_auxiliary_index_layers(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "config.json").write_text(
+                json.dumps({"num_hidden_layers": 1}),
+                encoding="utf-8",
+            )
+            save_file(
+                {
+                    "model.embed_tokens.weight": torch.ones(2, 2),
+                    "model.layers.0.weight": torch.ones(2, 2),
+                    "model.layers.1.weight": torch.ones(2, 2),
+                    "model.norm.weight": torch.ones(2),
+                    "lm_head.weight": torch.ones(2, 2),
+                },
+                root / "model.safetensors",
+            )
+            split_path = Path(
+                split_and_save_layers(
+                    root,
+                    layer_names={
+                        "embed": "model.embed_tokens",
+                        "layer_prefix": "model.layers",
+                        "norm": "model.norm",
+                        "lm_head": "lm_head",
+                    },
+                )
+            )
+
+            saved_names = {path.name for path in split_path.glob("*.safetensors")}
+
+        self.assertIn("model.layers.0.safetensors", saved_names)
+        self.assertNotIn("model.layers.1.safetensors", saved_names)
+
+    def test_delete_original_removes_final_multishard_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "config.json").write_text(
+                json.dumps({"num_hidden_layers": 1}), encoding="utf-8"
+            )
+            shard_one = root / "model-00001-of-00002.safetensors"
+            shard_two = root / "model-00002-of-00002.safetensors"
+            save_file(
+                {
+                    "model.embed_tokens.weight": torch.ones(2, 2),
+                    "model.layers.0.weight": torch.ones(2, 2),
+                },
+                shard_one,
+            )
+            save_file(
+                {
+                    "model.norm.weight": torch.ones(2),
+                    "lm_head.weight": torch.ones(2, 2),
+                },
+                shard_two,
+            )
+            weight_map = {
+                "model.embed_tokens.weight": shard_one.name,
+                "model.layers.0.weight": shard_one.name,
+                "model.norm.weight": shard_two.name,
+                "lm_head.weight": shard_two.name,
+            }
+            (root / "model.safetensors.index.json").write_text(
+                json.dumps(
+                    {
+                        "metadata": {"total_size": shard_one.stat().st_size + shard_two.stat().st_size},
+                        "weight_map": weight_map,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            split_and_save_layers(root, delete_original=True)
+
+            self.assertFalse(shard_one.exists())
+            self.assertFalse(shard_two.exists())
+
+    def test_compression_ratios(self):
+        self.assertEqual(estimated_split_size_bytes(10_000, None), 10_000)
+        self.assertEqual(estimated_split_size_bytes(10_000, "8bit"), 5_000)
+        self.assertEqual(estimated_split_size_bytes(10_000, "4bit"), 2_813)
+        with self.assertRaises(ValueError):
+            estimated_split_size_bytes(10_000, "3bit")
+
+    def test_prequantized_checkpoint_rejects_stacked_compression(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self._write_model_metadata(root, "GlmMoeDsaForCausalLM", "model.layers")
+            config_path = root / "config.json"
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            config["quantization_config"] = {"quant_method": "fp8"}
+            config_path.write_text(json.dumps(config), encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                inspect_model(str(root), compression="4bit")

--- a/air_llm/tests/test_prequantized_loading.py
+++ b/air_llm/tests/test_prequantized_loading.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from ..airllm.airllm_base import AirLLMBaseModel
+
+
+class _PackedModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight_packed = nn.Parameter(
+            torch.empty(4, dtype=torch.int32, device="meta"), requires_grad=False
+        )
+        self.weight_scale = nn.Parameter(
+            torch.empty(2, dtype=torch.float32, device="meta"), requires_grad=False
+        )
+
+
+class TestPrequantizedLoading(unittest.TestCase):
+    def test_packed_weights_and_scales_keep_checkpoint_dtypes(self):
+        streamed = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        streamed.model = _PackedModule()
+        streamed.running_device = "cpu"
+        streamed.running_dtype = torch.bfloat16
+        streamed.hf_quantizer = SimpleNamespace(
+            pre_quantized=True,
+            param_needs_quantization=lambda model, name: False,
+        )
+        state = {
+            "weight_packed": torch.tensor([1, 2, 3, 4], dtype=torch.int32),
+            "weight_scale": torch.tensor([0.25, 0.5], dtype=torch.float32),
+        }
+
+        streamed.move_layer_to_device(state)
+
+        self.assertEqual(streamed.model.weight_packed.dtype, torch.int32)
+        self.assertEqual(streamed.model.weight_scale.dtype, torch.float32)

--- a/air_llm/tests/test_server.py
+++ b/air_llm/tests/test_server.py
@@ -1,0 +1,72 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from ..airllm.server import _generate_chat
+from ..airllm.server import create_app
+
+
+class FakeTokenizer:
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        return "prompt"
+
+    def __call__(self, prompt, return_tensors=None, return_attention_mask=None):
+        return {
+            "input_ids": torch.tensor([[10, 11]]),
+            "attention_mask": torch.tensor([[1, 1]]),
+        }
+
+    def decode(self, generated, skip_special_tokens=False):
+        return "answer"
+
+
+class FakeModel:
+    tokenizer = FakeTokenizer()
+    device = torch.device("cpu")
+
+    def generate(self, **kwargs):
+        return SimpleNamespace(sequences=torch.tensor([[10, 11, 12, 13, 14]]))
+
+
+class TestServer(unittest.TestCase):
+    def test_generates_only_completion_tokens(self):
+        text, prompt_tokens, completion_tokens = _generate_chat(
+            FakeModel(),
+            [{"role": "user", "content": "hello"}],
+            max_tokens=3,
+            temperature=0,
+            top_p=1,
+        )
+        self.assertEqual(text, "answer")
+        self.assertEqual(prompt_tokens, 2)
+        self.assertEqual(completion_tokens, 3)
+
+    def test_rejects_non_text_messages(self):
+        with self.assertRaises(ValueError):
+            _generate_chat(
+                FakeModel(),
+                [{"role": "user", "content": [{"type": "image"}]}],
+                max_tokens=3,
+                temperature=0,
+                top_p=1,
+            )
+
+    def test_openai_compatible_chat_route(self):
+        from fastapi.testclient import TestClient
+
+        client = TestClient(create_app(FakeModel(), "fake-model"))
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "fake-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 3,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["object"], "chat.completion")
+        self.assertEqual(payload["choices"][0]["message"]["content"], "answer")
+        self.assertEqual(payload["usage"]["total_tokens"], 5)

--- a/air_llm/tests/test_streaming_cpu_integration.py
+++ b/air_llm/tests/test_streaming_cpu_integration.py
@@ -1,0 +1,70 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM
+
+from ..airllm.airllm_base import AirLLMBaseModel
+
+
+class TestStreamingCpuIntegration(unittest.TestCase):
+    @staticmethod
+    def _config():
+        return LlamaConfig(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+            tie_word_embeddings=False,
+        )
+
+    def test_tiny_llama_matches_full_model(self):
+        torch.manual_seed(7)
+        config = self._config()
+        reference = LlamaForCausalLM(config).eval()
+        input_ids = torch.tensor([[1, 2, 3, 4]])
+        with torch.inference_mode():
+            expected = reference(input_ids=input_ids, use_cache=False).logits
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir)
+            reference.save_pretrained(model_path)
+            with patch.object(AirLLMBaseModel, "get_tokenizer", return_value=None):
+                streamed = AirLLMBaseModel(
+                    model_path,
+                    device="cpu",
+                    prefetching=False,
+                )
+            with torch.inference_mode():
+                actual = streamed(input_ids=input_ids, use_cache=False).logits
+
+        torch.testing.assert_close(actual, expected)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA/ROCm device")
+    def test_tiny_llama_streams_on_gpu(self):
+        torch.manual_seed(11)
+        reference = LlamaForCausalLM(self._config()).eval()
+        input_ids = torch.tensor([[1, 2, 3, 4]])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = Path(temp_dir)
+            reference.save_pretrained(model_path)
+            reference = reference.to("cuda")
+            with torch.inference_mode():
+                expected = reference(input_ids=input_ids.to("cuda"), use_cache=False).logits.cpu()
+
+            with patch.object(AirLLMBaseModel, "get_tokenizer", return_value=None):
+                streamed = AirLLMBaseModel(
+                    model_path,
+                    device="cuda:0",
+                    prefetching=False,
+                )
+            with torch.inference_mode():
+                actual = streamed(input_ids=input_ids.to("cuda"), use_cache=False).logits.cpu()
+
+        torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Summary

- add a dedicated GLM loader with checkpoint-preserving FP8 expert handling
- add a Kimi text-model loader with projection-at-a-time compressed-tensors INT4 dequantization
- propagate cache and device settings and validate unsupported runtime combinations
- add capacity preflight and a localhost OpenAI-compatible inference API
- document GLM-5.2-FP8 and Kimi-K2.7-Code usage and constraints

## Validation

- unit tests: 30 run, 27 passed, 3 skipped
- Kimi ROCm-focused tests: 7 passed
- GLM-5.2 official remote-code meta-model structure validated
- Kimi-K2.7-Code official tiny meta-model structure validated
- compileall, pip check, diff check, and secret scan passed

## Known limitation

Full end-to-end generation with the 703.72 GiB and 554.27 GiB checkpoints was not run because the development machine does not currently have enough local storage for either checkpoint plus the AirLLM split cache. The implementation therefore has architecture-level, loader-level, tensor-routing, and device-kernel validation, but not a completed full-checkpoint inference run.