### PR TITLE
Fix 4-bit disk-space check demanding ~3.5x the model size

### DIFF
--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -161,8 +161,12 @@ def check_space(checkpoint_path, layer_shards_saving_path=None, compression=None
         for saved_split_file in glob(str(Path(layer_shards_saving_path) / splitted_model_dir_name / '*')):
             total_saved_split_files_size_bytes += os.path.getsize(saved_split_file)
 
+    # Compression shrinks the on-disk split, so the space we need to reserve is a *fraction* of the
+    # original checkpoint size: ~0.28x for 4-bit (4/16 bits plus quant-state overhead) and ~0.5x for
+    # 8-bit. The 4-bit case previously divided by 0.2813, which inflated the estimate to ~3.55x the
+    # original size and made check_space raise NotEnoughSpaceException even when there was ample room.
     if compression == '4bit':
-        total_shard_files_size_bytes = int(total_shard_files_size_bytes / 0.2813)
+        total_shard_files_size_bytes = int(total_shard_files_size_bytes * 0.2813)
     elif compression == '8bit':
         total_shard_files_size_bytes = total_shard_files_size_bytes // 2
 

--- a/air_llm/tests/test_check_space.py
+++ b/air_llm/tests/test_check_space.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import airllm.utils as utils
+from airllm.utils import check_space, NotEnoughSpaceException
+
+
+class TestCheckSpace(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmpdir.name)
+        # one "checkpoint" file of exactly 1000 bytes
+        with open(self.root / 'pytorch_model.bin', 'wb') as f:
+            f.write(b'\0' * 1000)
+        self._orig_disk_usage = utils.shutil.disk_usage
+
+    def tearDown(self):
+        utils.shutil.disk_usage = self._orig_disk_usage
+        self.tmpdir.cleanup()
+
+    def _set_free(self, free_bytes):
+        utils.shutil.disk_usage = lambda _p: (10 ** 12, 0, free_bytes)
+
+    def test_no_compression_thresholds(self):
+        self._set_free(1100)   # > 1000 original
+        check_space(self.root)  # should not raise
+        self._set_free(900)    # < 1000
+        with self.assertRaises(NotEnoughSpaceException):
+            check_space(self.root)
+
+    def test_8bit_needs_about_half(self):
+        # 8-bit split ~= 500 bytes
+        self._set_free(600)
+        check_space(self.root, compression='8bit')  # should not raise
+        self._set_free(400)
+        with self.assertRaises(NotEnoughSpaceException):
+            check_space(self.root, compression='8bit')
+
+    def test_4bit_needs_about_a_quarter_not_more_than_original(self):
+        # 4-bit split ~= int(1000 * 0.2813) = 281 bytes.
+        # 300 bytes of free space is plenty; the old code estimated ~3554 bytes and wrongly raised.
+        self._set_free(300)
+        check_space(self.root, compression='4bit')  # should NOT raise
+        # below the real requirement it should still raise
+        self._set_free(200)
+        with self.assertRaises(NotEnoughSpaceException):
+            check_space(self.root, compression='4bit')
+
+    def test_4bit_needs_less_space_than_8bit(self):
+        # For the same model, 4-bit must require less free space than 8-bit. With total=1000,
+        # 4-bit needs ~281 and 8-bit needs ~500, so 300 bytes free clears 4-bit but not 8-bit.
+        self._set_free(300)
+        check_space(self.root, compression='4bit')  # ok
+        with self.assertRaises(NotEnoughSpaceException):
+            check_space(self.root, compression='8bit')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Fix the 4-bit branch of `check_space()`, which over-estimated the disk space needed by ~12.6x and could block `compression='4bit'` with a spurious `NotEnoughSpaceException`.

## Why

`check_space()` reserves free disk for the split it's about to write. Compression makes that split smaller, so the estimate should be a *fraction* of the original checkpoint size. The 8-bit branch does this correctly:

```python
elif compression == '8bit':
    total_shard_files_size_bytes = total_shard_files_size_bytes // 2   # ~0.5x
```

But the 4-bit branch **divided** by the ratio instead of multiplying:

```python
if compression == '4bit':
    total_shard_files_size_bytes = int(total_shard_files_size_bytes / 0.2813)   # ~3.55x (!)
```

`1000 / 0.2813 ≈ 3554` — the "space needed" estimate ends up **larger than the uncompressed model**, and ~7x the 8-bit estimate, even though a 4-bit split is the *smallest* of the three.

Concretely: loading a local checkpoint with `compression='4bit'` and the default `delete_original=False` raises `NotEnoughSpaceException` unless you have ~3.5x the model size free — e.g. a local 72B fp16 model (~145 GB) demands ~515 GB free even though the 4-bit split is only ~40 GB.

## Fix

Multiply by `0.2813` (4/16 bits + quant-state overhead ≈ 0.28x), so the 4-bit estimate is ~0.28x the original — smaller than 8-bit's 0.5x, which is the correct ordering:

```python
if compression == '4bit':
    total_shard_files_size_bytes = int(total_shard_files_size_bytes * 0.2813)
```

## Testing

`python -m pytest air_llm/tests/test_check_space.py` — 4 offline tests (no network, no GPU; `shutil.disk_usage` is monkeypatched to control free space), all pass:

- no-compression raises below the original size, passes above it
- 8-bit needs ~0.5x
- 4-bit needs ~0.28x (300 bytes free clears a 1000-byte model; the old code wrongly required ~3554)
- 4-bit requires less free space than 8-bit for the same model

The two pre-existing branches (no-compression, 8-bit) are unchanged in behavior and covered by the tests as a guard.
