### PR TITLE
Load local single-file checkpoints instead of failing

### DIFF
--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -395,11 +395,17 @@ def find_or_create_local_splitted_path(model_local_path_or_repo_id, layer_shards
 
     # try local model path, if the model exist split and save there
     if os.path.exists(model_local_path_or_repo_id):
-        if os.path.exists(Path(model_local_path_or_repo_id) / 'pytorch_model.bin.index.json') or \
-           os.path.exists(Path(model_local_path_or_repo_id) / 'model.safetensors.index.json'):
-            print(f"found index file...")
-            return Path(model_local_path_or_repo_id), split_and_save_layers(model_local_path_or_repo_id, layer_shards_saving_path,
-                                                                            compression=compression, layer_names=layer_names, delete_original=delete_original)
+        local_path = Path(model_local_path_or_repo_id)
+        # Recognize every checkpoint layout split_and_save_layers can handle: sharded (an index.json)
+        # *and* single-file (a lone model.safetensors / pytorch_model.bin, common for <=7B models).
+        # Previously only the index.json files were checked, so a local single-file model fell through
+        # to snapshot_download(local_path), which treats the path as a repo id and fails.
+        weight_files = ['model.safetensors.index.json', 'pytorch_model.bin.index.json',
+                        'model.safetensors', 'pytorch_model.bin']
+        if any(os.path.exists(local_path / f) for f in weight_files):
+            print(f"found local model weights...")
+            return local_path, split_and_save_layers(model_local_path_or_repo_id, layer_shards_saving_path,
+                                                      compression=compression, layer_names=layer_names, delete_original=delete_original)
         else:
             print(
                 f"Found local directory in {model_local_path_or_repo_id}, but didn't find downloaded model. Try using {model_local_path_or_repo_id} as a HF repo...")

--- a/air_llm/tests/test_local_model_detection.py
+++ b/air_llm/tests/test_local_model_detection.py
@@ -1,0 +1,77 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+import airllm.utils as utils
+
+
+class TestLocalModelDetection(unittest.TestCase):
+    """
+    find_or_create_local_splitted_path must recognize a local checkpoint (so it splits it in place)
+    instead of falling through to snapshot_download(), which treats the local path as a repo id and
+    fails. This must hold for single-file checkpoints, not just sharded (index.json) ones.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.root = self.tmpdir.name
+        self._orig_split = utils.split_and_save_layers
+        self._orig_download = utils.huggingface_hub.snapshot_download
+        self.calls = {'split': False, 'download': False}
+
+        def fake_split(*args, **kwargs):
+            self.calls['split'] = True
+            return 'SPLIT_PATH'
+
+        def fake_download(*args, **kwargs):
+            self.calls['download'] = True
+            raise AssertionError('snapshot_download should not be called for a local checkpoint')
+
+        utils.split_and_save_layers = fake_split
+        utils.huggingface_hub.snapshot_download = fake_download
+
+    def tearDown(self):
+        utils.split_and_save_layers = self._orig_split
+        utils.huggingface_hub.snapshot_download = self._orig_download
+        self.tmpdir.cleanup()
+
+    def _run(self):
+        return utils.find_or_create_local_splitted_path(self.root, layer_names={
+            'embed': 'model.embed_tokens', 'layer_prefix': 'model.layers',
+            'norm': 'model.norm', 'lm_head': 'lm_head'})
+
+    def test_single_file_safetensors_is_split_locally(self):
+        save_file({'w': torch.zeros(2)}, os.path.join(self.root, 'model.safetensors'))
+        local_path, saved = self._run()
+        self.assertTrue(self.calls['split'])
+        self.assertFalse(self.calls['download'])
+        self.assertEqual(Path(local_path), Path(self.root))
+
+    def test_single_file_bin_is_split_locally(self):
+        torch.save({'w': torch.zeros(2)}, os.path.join(self.root, 'pytorch_model.bin'))
+        self._run()
+        self.assertTrue(self.calls['split'])
+        self.assertFalse(self.calls['download'])
+
+    def test_sharded_index_still_split_locally(self):
+        with open(os.path.join(self.root, 'model.safetensors.index.json'), 'w') as f:
+            f.write('{}')
+        self._run()
+        self.assertTrue(self.calls['split'])
+        self.assertFalse(self.calls['download'])
+
+    def test_directory_without_weights_falls_through_to_download(self):
+        with open(os.path.join(self.root, 'config.json'), 'w') as f:
+            f.write('{}')
+        with self.assertRaises(AssertionError):
+            self._run()
+        self.assertFalse(self.calls['split'])
+        self.assertTrue(self.calls['download'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Let AirLLM load a **local** single-file checkpoint (a lone `model.safetensors` or `pytorch_model.bin` with no `index.json`), instead of failing.

## Why

`split_and_save_layers()` already handles single-file checkpoints (common for ≤7B models). But `find_or_create_local_splitted_path()` only recognized a *local* model when the directory contained one of the two `index.json` files:

```python
if os.path.exists(local / 'pytorch_model.bin.index.json') or \
   os.path.exists(local / 'model.safetensors.index.json'):
    ... split locally ...
else:
    # falls through to snapshot_download(model_local_path_or_repo_id)
```

So a local directory holding a single-file checkpoint (no index) fell through to `snapshot_download(local_path)`, which treats the local filesystem path as a Hugging Face repo id and fails. The README documents passing a local path to `from_pretrained(...)`, so this hits anyone pointing AirLLM at a locally-downloaded small model.

Reproduced on current `main` (offline): a temp dir with just `model.safetensors` never calls `split_and_save_layers` — it calls `snapshot_download` with the local path and errors.

## Fix

Recognize every layout `split_and_save_layers` supports — sharded *and* single-file, safetensors *and* bin — before falling back to treating the argument as a repo id:

```python
weight_files = ['model.safetensors.index.json', 'pytorch_model.bin.index.json',
                'model.safetensors', 'pytorch_model.bin']
if any(os.path.exists(local_path / f) for f in weight_files):
    ... split locally ...
```

A directory with genuinely no weights still falls through to the repo-id download path, unchanged.

## Testing

`python -m pytest air_llm/tests/test_local_model_detection.py` — 4 offline tests (no network, no GPU; `split_and_save_layers` and `snapshot_download` are monkeypatched to record which branch is taken), all pass:

- local single-file `model.safetensors` → split locally (was: download fallback → fail)
- local single-file `pytorch_model.bin` → split locally
- local sharded `*.index.json` → split locally (regression guard)
- local dir with no weights → still falls through to download
