### PR TITLE
Use the model's real generation config for custom architectures

### DIFF
--- a/air_llm/airllm/airllm_baichuan.py
+++ b/air_llm/airllm/airllm_baichuan.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .tokenization_baichuan import BaichuanTokenizer
 
 from .airllm_base import AirLLMBaseModel
@@ -20,8 +18,5 @@ class AirLLMBaichuan(AirLLMBaseModel):
     def get_tokenizer(self, hf_token=None):
         # use this hack util the bug is fixed: https://huggingface.co/baichuan-inc/Baichuan2-7B-Base/discussions/2
         return BaichuanTokenizer.from_pretrained(self.model_local_path, use_fast=False, trust_remote_code=True)
-
-    def get_generation_config(self):
-        return GenerationConfig()
 
 

--- a/air_llm/airllm/airllm_chatglm.py
+++ b/air_llm/airllm/airllm_chatglm.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .airllm_base import AirLLMBaseModel
 
 
@@ -15,9 +13,6 @@ class AirLLMChatGLM(AirLLMBaseModel):
 
     def get_use_better_transformer(self):
         return False
-
-    def get_generation_config(self):
-        return GenerationConfig()
 
     def get_sequence_len(self, seq):
         return seq.shape[0]

--- a/air_llm/airllm/airllm_internlm.py
+++ b/air_llm/airllm/airllm_internlm.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .airllm_base import AirLLMBaseModel
 
 
@@ -15,7 +13,5 @@ class AirLLMInternLM(AirLLMBaseModel):
 
     def get_use_better_transformer(self):
         return False
-    def get_generation_config(self):
-        return GenerationConfig()
 
 

--- a/air_llm/airllm/airllm_mistral.py
+++ b/air_llm/airllm/airllm_mistral.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .airllm_base import AirLLMBaseModel
 
 
@@ -15,7 +13,5 @@ class AirLLMMistral(AirLLMBaseModel):
 
     def get_use_better_transformer(self):
         return False
-    def get_generation_config(self):
-        return GenerationConfig()
 
 

--- a/air_llm/airllm/airllm_mixtral.py
+++ b/air_llm/airllm/airllm_mixtral.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .airllm_base import AirLLMBaseModel
 
 
@@ -15,8 +13,5 @@ class AirLLMMixtral(AirLLMBaseModel):
 
     def get_use_better_transformer(self):
         return False
-
-    def get_generation_config(self):
-        return GenerationConfig()
 
 

--- a/air_llm/airllm/airllm_qwen.py
+++ b/air_llm/airllm/airllm_qwen.py
@@ -1,6 +1,4 @@
 
-from transformers import GenerationConfig
-
 from .airllm_base import AirLLMBaseModel
 
 
@@ -15,9 +13,6 @@ class AirLLMQWen(AirLLMBaseModel):
 
     def get_use_better_transformer(self):
         return False
-    def get_generation_config(self):
-        return GenerationConfig()
-
 
     def get_past_key_values_cache_seq_len(self, past_key_values):
         return past_key_values[0][0].shape[1]

--- a/air_llm/airllm/airllm_qwen2.py
+++ b/air_llm/airllm/airllm_qwen2.py
@@ -1,7 +1,4 @@
 
-from transformers import GenerationConfig
-
-
 from .airllm_base import AirLLMBaseModel
 
 

--- a/air_llm/tests/test_generation_config.py
+++ b/air_llm/tests/test_generation_config.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+
+from transformers import GenerationConfig
+
+from airllm.airllm_base import AirLLMBaseModel
+
+
+class TestGenerationConfig(unittest.TestCase):
+    def test_base_loads_the_models_real_generation_config(self):
+        # base.get_generation_config() should read the model's generation_config.json (eos_token_id,
+        # etc.) rather than returning an empty config that transformers would fall back to defaults on.
+        with tempfile.TemporaryDirectory() as d:
+            GenerationConfig(eos_token_id=2, bos_token_id=1, max_new_tokens=7).save_pretrained(d)
+
+            obj = AirLLMBaseModel.__new__(AirLLMBaseModel)  # skip heavy __init__
+            obj.model_local_path = d
+            cfg = obj.get_generation_config()
+
+            self.assertEqual(cfg.eos_token_id, 2)
+            self.assertEqual(cfg.max_new_tokens, 7)
+
+    def test_base_falls_back_to_empty_config_when_none_present(self):
+        with tempfile.TemporaryDirectory() as d:
+            obj = AirLLMBaseModel.__new__(AirLLMBaseModel)
+            obj.model_local_path = d
+            cfg = obj.get_generation_config()
+            self.assertIsInstance(cfg, GenerationConfig)  # no crash, usable default
+
+    def test_custom_arch_subclasses_do_not_shadow_generation_config(self):
+        # The custom-architecture subclasses used to override get_generation_config() to return an
+        # empty GenerationConfig(), discarding the model's real generation defaults. They must inherit
+        # base's loader instead. (Baichuan pulls in an optional tokenizer dep, so import defensively.)
+        checked = 0
+        for module_name, cls_name in (
+            ('airllm.airllm_qwen', 'AirLLMQWen'),
+            ('airllm.airllm_chatglm', 'AirLLMChatGLM'),
+            ('airllm.airllm_internlm', 'AirLLMInternLM'),
+            ('airllm.airllm_qwen2', 'AirLLMQWen2'),
+            ('airllm.airllm_mistral', 'AirLLMMistral'),
+            ('airllm.airllm_mixtral', 'AirLLMMixtral'),
+            ('airllm.airllm_baichuan', 'AirLLMBaichuan'),
+        ):
+            try:
+                mod = __import__(module_name, fromlist=[cls_name])
+                cls = getattr(mod, cls_name)
+            except Exception:
+                continue  # optional dependency missing; skip that family
+            self.assertIs(cls.get_generation_config, AirLLMBaseModel.get_generation_config,
+                          f"{cls_name} should inherit get_generation_config from AirLLMBaseModel")
+            checked += 1
+        self.assertGreater(checked, 0, "expected to check at least one subclass")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Make the custom-architecture subclasses (ChatGLM / QWen / Baichuan / InternLM, plus Mistral / Mixtral) use the model's **real** generation config instead of an empty one.

## Why

These subclasses override `get_generation_config()` to return an empty `GenerationConfig()`:

```python
def get_generation_config(self):
    return GenerationConfig()
```

After the v3.0 rewrite, transformers owns the forward/generation pass and `model.generate()` uses `model.generation_config`. `AirLLMBaseModel` sets that from `get_generation_config()`, and its own implementation already loads the real config with a safe fallback:

```python
def get_generation_config(self):
    try:
        return GenerationConfig.from_pretrained(self.model_local_path)
    except Exception:
        return GenerationConfig()
```

So **generic** architectures already generate with the model's real defaults (`eos_token_id`, `bos_token_id`, sampling settings, …), but the **custom-arch** subclasses discard them via the empty override. The most visible symptom is a missing `eos_token_id`, so generation for these models won't stop early and runs to `max_new_tokens`.

The override looks like leftover pre-rewrite code — the same subclasses still carry other now-unused helpers (`get_pos_emb_args`, `get_past_key_value_args`, …) from when AirLLM drove the forward pass itself.

## Fix

- Remove the stale `get_generation_config()` override so these classes inherit `AirLLMBaseModel.get_generation_config` (which loads the real config, with the existing empty-config fallback — so this can only match or improve current behavior, never regress).
- Drop the now-unused `GenerationConfig` imports.

## Testing

`python -m pytest air_llm/tests/test_generation_config.py` — 3 offline tests (no network/GPU), all pass:

- base `get_generation_config()` loads a real `generation_config.json` (asserts `eos_token_id` / `max_new_tokens`)
- base falls back to a usable empty config when none is present (no crash)
- the custom-arch subclasses no longer shadow `get_generation_config` (inherit base's)

**What I could not verify:** I don't have Apple silicon or the specific custom models on hand, so I verified the config-loading logic and the inheritance offline but did not run end-to-end generation for ChatGLM/QWen/Baichuan/InternLM themselves. The change is a strict superset of the old behavior (base already has the empty-config fallback), so the risk is low, but flagging it explicitly.
