### PR TITLE
Fix the unit tests so they can actually run

### DIFF
--- a/air_llm/tests/test_automodel.py
+++ b/air_llm/tests/test_automodel.py
@@ -1,31 +1,84 @@
-import sys
+import os
 import unittest
 
-#sys.path.insert(0, '../airllm')
-
-from ..airllm.auto_model import AutoModel
-
+import airllm.auto_model as auto_model_mod
+from airllm.auto_model import AutoModel
 
 
-class TestAutoModel(unittest.TestCase):
+class _FakeConfig:
+    def __init__(self, architectures):
+        self.architectures = architectures
+
+
+class TestAutoModelRouting(unittest.TestCase):
+    """
+    AutoModel routing, tested offline by faking the config lookup.
+
+    Since the v3.0 rewrite only architectures with a non-standard module layout get a dedicated
+    AirLLM subclass (ARCH_OVERRIDES); every other *ForCausalLM streams through the generic
+    AirLLMBaseModel, which is what lets newly released models work without code changes.
+    """
+
     def setUp(self):
-        pass
-    def tearDown(self):
-        pass
+        self._orig = auto_model_mod.AutoConfig.from_pretrained
 
-    def test_auto_model_should_return_correct_model(self):
+    def tearDown(self):
+        auto_model_mod.AutoConfig.from_pretrained = self._orig
+
+    def _route(self, architecture):
+        def fake(path, trust_remote_code=None, **kwargs):
+            return _FakeConfig([architecture] if architecture else [])
+
+        auto_model_mod.AutoConfig.from_pretrained = staticmethod(fake)
+        module, cls = AutoModel.get_module_class('some/repo')
+        self.assertEqual(module, 'airllm')
+        return cls
+
+    def test_custom_architectures_get_dedicated_classes(self):
+        mapping = {
+            'ChatGLMModel': 'AirLLMChatGLM',
+            'ChatGLMForConditionalGeneration': 'AirLLMChatGLM',
+            'QWenLMHeadModel': 'AirLLMQWen',
+            'BaichuanForCausalLM': 'AirLLMBaichuan',
+            'BaiChuanForCausalLM': 'AirLLMBaichuan',
+            'InternLMForCausalLM': 'AirLLMInternLM',
+        }
+        for arch, expected in mapping.items():
+            self.assertEqual(self._route(arch), expected, f"{arch} should route to {expected}")
+
+    def test_standard_architectures_use_generic_streaming_model(self):
+        # These used to have dedicated subclasses (AirLLMLlama2/Mistral/Mixtral) but now go through
+        # the generic path, which is why the old assertions in this test were stale.
+        for arch in ('LlamaForCausalLM', 'MistralForCausalLM', 'MixtralForCausalLM',
+                     'Qwen2ForCausalLM', 'Qwen3ForCausalLM', 'Phi3ForCausalLM',
+                     'Gemma2ForCausalLM', 'DeepseekV3ForCausalLM'):
+            self.assertEqual(self._route(arch), 'AirLLMBaseModel',
+                             f"{arch} should use the generic streaming model")
+
+    def test_unknown_or_missing_architecture_falls_back_to_generic(self):
+        self.assertEqual(self._route('SomeBrandNewForCausalLM'), 'AirLLMBaseModel')
+        self.assertEqual(self._route(None), 'AirLLMBaseModel')
+
+
+@unittest.skipUnless(os.environ.get('AIRLLM_TEST_NETWORK'),
+                     "set AIRLLM_TEST_NETWORK=1 to run tests that download configs from Hugging Face")
+class TestAutoModelRoutingAgainstHub(unittest.TestCase):
+    """Same routing, resolved against the real Hugging Face configs. Needs network access."""
+
+    def test_real_repo_ids_route_as_expected(self):
         mapping_dict = {
-            'garage-bAInd/Platypus2-7B': 'AirLLMLlama2',
+            'garage-bAInd/Platypus2-7B': 'AirLLMBaseModel',
+            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMBaseModel',
+            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMBaseModel',
             'Qwen/Qwen-7B': 'AirLLMQWen',
             'internlm/internlm-chat-7b': 'AirLLMInternLM',
             'THUDM/chatglm3-6b-base': 'AirLLMChatGLM',
             'baichuan-inc/Baichuan2-7B-Base': 'AirLLMBaichuan',
-            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMMistral',
-            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMMixtral'
         }
+        for repo_id, expected in mapping_dict.items():
+            module, cls = AutoModel.get_module_class(repo_id)
+            self.assertEqual(cls, expected, f"expecting {expected} for {repo_id}")
 
 
-        for k,v in mapping_dict.items():
-            module, cls = AutoModel.get_module_class(k)
-            self.assertEqual(cls, v, f"expecting {v}")
-
+if __name__ == '__main__':
+    unittest.main()

--- a/air_llm/tests/test_compression.py
+++ b/air_llm/tests/test_compression.py
@@ -1,14 +1,17 @@
-import sys
 import unittest
 
 import torch
-sys.path.insert(0, '../airllm')
 
-from airllm import compress_layer_state_dict, uncompress_layer_state_dict
+# These live in airllm.utils and are not re-exported from the package root, so importing them
+# from `airllm` directly raised ImportError and the whole module failed to collect.
+from airllm.utils import compress_layer_state_dict, uncompress_layer_state_dict
 
 
 
 
+# Compression goes through bitsandbytes, which needs a CUDA device: the state dicts are quantized
+# with .cuda() tensors. Skip (rather than error) on CPU-only machines and CI runners.
+@unittest.skipUnless(torch.cuda.is_available(), "compression requires a CUDA GPU")
 class TestCompression(unittest.TestCase):
     def setUp(self):
         pass


### PR DESCRIPTION
## What

Make the two existing test modules in `air_llm/tests/` actually runnable. Right now neither one does.

## Why

**`test_compression.py` fails at import.** It does:

```python
from airllm import compress_layer_state_dict, uncompress_layer_state_dict
```

but those functions live in `airllm.utils` and are not re-exported from the package root (`__init__.py` exports `split_and_save_layers` and `NotEnoughSpaceException` only). So collecting the module raises:

```
ImportError: cannot import name 'compress_layer_state_dict' from 'airllm'
```

Because it's a collection error, it takes down the whole test run, not just that module. Separately, the test quantizes with `.cuda()` tensors, so even once importable it errors rather than skips on a CPU-only machine.

**`test_automodel.py` went stale in the v3.0 rewrite.** It still asserts:

```python
'garage-bAInd/Platypus2-7B': 'AirLLMLlama2',
'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMMistral',
'mistralai/Mixtral-8x7B-v0.1': 'AirLLMMixtral',
```

but the rewrite routes all standard architectures through the generic `AirLLMBaseModel` (only `ARCH_OVERRIDES` archs get dedicated classes), so those three assertions now fail. It also used a relative import (`from ..airllm.auto_model import ...`) that disagrees with the absolute imports in the other module — the two couldn't be collected by the same run — and it needed network access to resolve every repo id.

## Changes

- **`test_compression.py`**: import from `airllm.utils`; skip instead of error when CUDA is unavailable.
- **`test_automodel.py`**: test the routing offline by faking the config lookup, asserting current behavior — custom archs (ChatGLM/QWen/Baichuan/InternLM) → dedicated classes; standard archs (Llama, Mistral, Mixtral, Qwen2/3, Phi3, Gemma2, DeepseekV3) and unknown/missing archs → `AirLLMBaseModel`. The original against-the-Hub check is kept with corrected expectations, gated behind `AIRLLM_TEST_NETWORK=1`.
- Use absolute imports in both so one invocation collects the whole directory.

No production code is touched, and no new dependency is added (the network/GPU gates use `unittest.skipUnless`, not pytest markers, so the suite still runs under plain `unittest`).

## Testing

From `air_llm/`, both runners agree — 3 passed, 2 skipped (the GPU test and the network test):

```
python -m pytest -v
python -m unittest discover -s tests -t .    # Ran 5 tests ... OK (skipped=2)
```

Also confirmed the new offline routing assertions genuinely exercise `ARCH_OVERRIDES` (they fail if the mapping is changed).

Related: I opened #312 proposing a small CI workflow. This PR is useful on its own regardless of that — but it's also the prerequisite that would let CI run the suite green, so I split it out rather than bundling it there.
