### PR TITLE
Add DeepSeek V4 Flash selective expert streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 * [Bloome — build & run AI agent teams in the cloud, zero setup](https://bloome.im/app?ref=G6BYnov0&utm_medium=github&utm_source=lyogavin-airllm-ivor-202606)
 
 ## Updates
+[2026/08] **DeepSeek V4 Flash** support: native checkpoint loading and routed-expert streaming let the model run within a configurable CUDA memory budget. A full generation was verified at 14 GiB, and the streaming path at 4 GiB. Install with `pip install 'airllm[deepseek-v4]'`.
+
 [2026/07] **Kimi K3 (2.8T)** support: the largest open-source model runs on a single card in **3.72GB** of VRAM, measured end to end on one RTX 6000 Ada. Per-expert streaming loads only the experts a token actually routes to. K3 brings three requirements of its own: `pip install compressed-tensors flash-attn` (its model code mandates flash attention regardless of what you request), a CUDA 12 build of torch, since no prebuilt flash-attn wheel exists for CUDA 13 yet, and `transformers` 4.56.x, as its remote code does not load on 5.x.
 
 [2026/06] **v3.0**: FP8 model support + the latest models. Run **DeepSeek-V3 (671B) on ~12GB** and **Qwen3-235B on ~3GB**, plus Qwen3, Llama 3.x/4, DeepSeek V2/V3, Phi-4, Gemma and more — all through a single `AutoModel`.
@@ -171,6 +173,28 @@ When initialize the model, we support the following configurations:
 * **hf_token**: huggingface token can be provided here if downloading gated models like: *meta-llama/Llama-2-7b-hf*
 * **prefetching**: prefetching to overlap the model loading and compute. By default, turned on. For now, only AirLLMLlama2 supports this.
 * **delete_original**: if you don't have too much disk space, you can set delete_original to true to delete the original downloaded hugging face model, only keep the transformed one to save half of the disk space. 
+* **max_vram_gb**: for DeepSeek V4, set a numeric per-process CUDA allocator budget. AirLLM uses the checkpoint's tensor sizes to choose ordinary-weight residency and a bounded expert cache.
+
+### DeepSeek V4 Flash
+
+Install the model-specific dependencies and pass a VRAM budget through `AutoModel`:
+
+```bash
+pip install 'airllm[deepseek-v4]'
+```
+
+```python
+from airllm import AutoModel
+
+model = AutoModel.from_pretrained(
+    "deepseek-ai/DeepSeek-V4-Flash-0731",
+    max_vram_gb=14,
+)
+```
+
+The budget is measured in GiB and applies to PyTorch's CUDA allocator. AirLLM reserves execution
+headroom, then uses the remainder to keep ordinary weights resident and cache routed experts when
+space permits. Longer contexts or other CUDA users may require a lower budget.
 
 ## MacOS
 
@@ -272,7 +296,7 @@ model.tokenizer.decode(generation_output.sequences[0])
 
 AirLLM works out of the box with **virtually every popular open LLM** — just pass its Hugging Face ID to `AutoModel.from_pretrained(...)`. That covers all the major families:
 
-**Llama** (2 / 3 / 3.1 / 3.3 / 4) · **Qwen** (1 / 2 / 2.5 / 3, including MoE and FP8) · **DeepSeek** (V2 / V3 / R1) · **Mistral & Mixtral** · **Phi** · **Gemma** · **ChatGLM** · **Baichuan** · **InternLM** · **Yi** — and most new models the day they're released.
+**Llama** (2 / 3 / 3.1 / 3.3 / 4) · **Qwen** (1 / 2 / 2.5 / 3, including MoE and FP8) · **DeepSeek** (V2 / V3 / V4 / R1) · **Mistral & Mixtral** · **Phi** · **Gemma** · **ChatGLM** · **Baichuan** · **InternLM** · **Yi** — and most new models the day they're released.
 
 ### Tiny GPU, huge models
 
@@ -286,6 +310,7 @@ The trick: AirLLM only ever keeps **one layer on the GPU at a time**, so the VRA
 | Llama 3.x 70B (full precision) | 70B | **~4 GB** |
 | Llama 3.1 405B | 405B | **~8 GB** |
 | DeepSeek-V3 | **671B** | **~12 GB** |
+| DeepSeek V4 Flash | sparse MoE | **~4 GB minimum, configurable** |
 
 Same one line of code for all of them — no special setup.
 

--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -32,6 +32,7 @@ else:
         ("AirLLMMistral", ".airllm_mistral"),
         ("AirLLMMixtral", ".airllm_mixtral"),
         ("AirLLMKimiK3", ".airllm_kimi_k3"),
+        ("AirLLMDeepseekV4", ".airllm_deepseek_v4"),
     ):
         try:
             _mod = __import__(__name__ + _module, fromlist=[_name])
@@ -41,4 +42,3 @@ else:
                 f"airllm: optional model class {_name} is unavailable ({_e}). "
                 f"This only affects that specific model family; the generic streaming path still works."
             )
-

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -72,6 +72,11 @@ class AirLLMBaseModel:
     # Layers larger than this are loaded into ordinary pageable memory instead.
     max_pinned_layer_bytes = 2 * 1024 ** 3
 
+    # Conservative default for existing adapters. Models with bounded streamed-layer allocations
+    # can opt out so CUDA reuses those blocks instead of synchronizing and returning them to the
+    # driver after every layer.
+    clean_memory_after_layer = True
+
     # Subclasses override this to point at non-standard module names.
     def set_layer_names_dict(self):
         self.layer_names_dict = {'embed': 'model.embed_tokens',
@@ -128,11 +133,17 @@ class AirLLMBaseModel:
 
         self.set_layer_names_dict()
 
+        # Most checkpoints use the same names as the runtime model. A few native releases use a
+        # different on-disk namespace, though; keep the runtime names for module traversal and hand
+        # the checkpoint names to the splitter. Subclasses can provide an ``aliases`` mapping for
+        # shard lookup without teaching the generic loader model-specific renames.
+        self.checkpoint_layer_names_dict = self.layer_names_dict.get('checkpoint', self.layer_names_dict)
+
         self.model_local_path, self.checkpoint_path = find_or_create_local_splitted_path(
             model_local_path_or_repo_id,
             layer_shards_saving_path,
             compression=compression,
-            layer_names=self.layer_names_dict,
+            layer_names=self.checkpoint_layer_names_dict,
             hf_token=hf_token,
             delete_original=delete_original)
 
@@ -333,9 +344,22 @@ class AirLLMBaseModel:
 
     # ---- weight streaming -------------------------------------------------------------------
 
+    def _checkpoint_layer_name(self, runtime_layer_name):
+        """Return the shard name corresponding to a runtime module name."""
+        aliases = self.checkpoint_layer_names_dict.get('aliases', {})
+        if runtime_layer_name in aliases:
+            return aliases[runtime_layer_name]
+
+        runtime_prefix = self.layer_names_dict['layer_prefix']
+        checkpoint_prefix = self.checkpoint_layer_names_dict['layer_prefix']
+        if runtime_layer_name.startswith(runtime_prefix + '.'):
+            return checkpoint_prefix + runtime_layer_name[len(runtime_prefix):]
+        return runtime_layer_name
+
     def load_layer_to_cpu(self, layer_name):
         t = time.time()
-        load_layer_output = load_layer(self.checkpoint_path, layer_name, self.profiling_mode)
+        checkpoint_layer_name = self._checkpoint_layer_name(layer_name)
+        load_layer_output = load_layer(self.checkpoint_path, checkpoint_layer_name, self.profiling_mode)
         elapsed_time = time.time() - t
 
         if self.profiling_mode:
@@ -606,12 +630,25 @@ class AirLLMBaseModel:
         self._streamed_set = set(self._streamed_indices)
 
         self._setup_expert_streaming()
+        resident_indices = list(self._configure_streaming_policy())
+        for idx in resident_indices:
+            self.move_layer_to_device(self._load_streamed_layer(idx))
+        if resident_indices:
+            resident_set = set(resident_indices)
+            self._streamed_indices = [
+                idx for idx in self._streamed_indices if idx not in resident_set
+            ]
+            self._streamed_set = set(self._streamed_indices)
 
         for idx in self._streamed_indices:
             module = self.layers[idx]
             module._airllm_idx = idx
             module.register_forward_pre_hook(self._pre_hook)
             module.register_forward_hook(self._post_hook)
+
+    def _configure_streaming_policy(self):
+        """Configure adapter-specific streaming and return modules to keep resident."""
+        return ()
 
     # ---- per-expert streaming ---------------------------------------------------------------
 
@@ -741,7 +778,8 @@ class AirLLMBaseModel:
                 set_module_tensor_to_device(self.model, param_name, 'meta')
         else:
             module.to('meta')
-        clean_memory()
+        if self.clean_memory_after_layer:
+            clean_memory()
         return output
 
     # ---- delegation to the underlying transformers model ------------------------------------

--- a/air_llm/airllm/airllm_deepseek_v4.py
+++ b/air_llm/airllm/airllm_deepseek_v4.py
@@ -1,0 +1,445 @@
+import math
+import numbers
+import re
+from collections import OrderedDict
+from types import MethodType
+
+import torch
+import torch.nn.functional as F
+
+from .airllm_base import AirLLMBaseModel
+from .utils import layer_tensor_sizes, load_layer_subset
+
+
+def _streamed_experts_forward(module, hidden_states, top_k_index, top_k_weights):
+    return module._airllm_owner._run_streamed_experts(
+        module, hidden_states, top_k_index, top_k_weights)
+
+
+class AirLLMDeepseekV4(AirLLMBaseModel):
+    """AirLLM adapter for the native DeepSeek-V4-Flash checkpoint.
+
+    V4's published weights use a flat DeepSeek namespace and store each routed expert separately,
+    while Transformers builds Hugging Face names and stacks all experts into two giant tensors.
+    The ordinary layer hooks still stream attention, routing, and shared-expert weights. This
+    adapter translates those keys and replaces only the stacked expert forward with safetensors
+    reads for the experts selected by the router.
+    """
+
+    _EXPERT_KEY = re.compile(
+        r"^layers\.(\d+)\.ffn\.experts\.(\d+)\.(w[123])\.(weight|scale)$")
+    # V4 releases each streamed layer before advancing. Keeping the allocator's blocks cached
+    # avoids 43 full GC / CUDA cache purges per generated token without retaining live weights.
+    clean_memory_after_layer = False
+
+    def __init__(
+        self,
+        *args,
+        max_vram_gb=None,
+        **kwargs,
+    ):
+        """Create a V4 adapter within an optional per-process CUDA memory budget."""
+        if max_vram_gb is not None:
+            if (
+                isinstance(max_vram_gb, bool)
+                or not isinstance(max_vram_gb, numbers.Real)
+                or not math.isfinite(max_vram_gb)
+                or max_vram_gb <= 0
+            ):
+                raise ValueError('max_vram_gb must be a positive finite number')
+        self.max_vram_gb = float(max_vram_gb) if max_vram_gb is not None else None
+        self.expert_cache_size = 0
+        self._expert_cache = {}
+        self._layer_tensor_sizes = {}
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _choose_vram_policy(
+        budget_bytes,
+        allocated_bytes,
+        resident_bytes,
+        largest_streamed_bytes,
+        expert_working_bytes,
+        expert_cache_unit_bytes,
+        max_cache_size,
+    ):
+        """Choose residency and a per-layer cache size within a byte budget."""
+        headroom = max(1024**3, int(budget_bytes * 0.10))
+        resident_working = max(headroom, expert_working_bytes)
+        keep_resident = allocated_bytes + resident_bytes + resident_working <= budget_bytes
+
+        if keep_resident:
+            fixed = allocated_bytes + resident_bytes
+            working = resident_working
+        else:
+            fixed = allocated_bytes
+            # Streaming briefly needs the largest ordinary module (usually the language head)
+            # alongside routed-expert workspace and allocator/KV headroom.
+            working = headroom + largest_streamed_bytes + expert_working_bytes
+
+        required = fixed + working
+        if required > budget_bytes:
+            return False, 0, working, required
+
+        cache_bytes = budget_bytes - required
+        cache_size = (
+            min(max_cache_size, cache_bytes // expert_cache_unit_bytes)
+            if expert_cache_unit_bytes else 0
+        )
+        return keep_resident, int(cache_size), working, required
+
+    def set_layer_names_dict(self):
+        self.layer_names_dict = {
+            'embed': 'model.embed_tokens',
+            'layer_prefix': 'model.layers',
+            'norm': 'model.norm',
+            'lm_head': 'lm_head',
+            'resident': ['model.hc_head'],
+            'checkpoint': {
+                'embed': 'embed',
+                'layer_prefix': 'layers',
+                'norm': 'norm',
+                'lm_head': 'head',
+                'groups': {
+                    'hc_head': ['hc_head_fn', 'hc_head_base', 'hc_head_scale'],
+                },
+                'aliases': {
+                    'model.embed_tokens': 'embed',
+                    'model.norm': 'norm',
+                    'lm_head': 'head',
+                    'model.hc_head': 'hc_head',
+                },
+            },
+        }
+
+    @staticmethod
+    def _translate_key(key):
+        is_quantization_scale = key.endswith('.scale')
+        top_level = {
+            'embed.weight': 'model.embed_tokens.weight',
+            'head.weight': 'lm_head.weight',
+            'norm.weight': 'model.norm.weight',
+            'hc_head_fn': 'model.hc_head.hc_fn',
+            'hc_head_base': 'model.hc_head.hc_base',
+            'hc_head_scale': 'model.hc_head.hc_scale',
+        }
+        if key in top_level:
+            return top_level[key]
+        if key.startswith('mtp.'):
+            return None
+        if AirLLMDeepseekV4._EXPERT_KEY.match(key):
+            # Routed experts never become stacked Transformers parameters. Their native keys are
+            # retained so the replacement expert forward can seek to each tensor independently.
+            return None
+
+        replacements = (
+            (r'^layers\.(\d+)\.attn_norm\.', r'model.layers.\1.input_layernorm.'),
+            (r'^layers\.(\d+)\.ffn_norm\.', r'model.layers.\1.post_attention_layernorm.'),
+            (r'^layers\.(\d+)\.hc_attn_fn$', r'model.layers.\1.attn_hc.fn'),
+            (r'^layers\.(\d+)\.hc_attn_base$', r'model.layers.\1.attn_hc.base'),
+            (r'^layers\.(\d+)\.hc_attn_scale$', r'model.layers.\1.attn_hc.scale'),
+            (r'^layers\.(\d+)\.hc_ffn_fn$', r'model.layers.\1.ffn_hc.fn'),
+            (r'^layers\.(\d+)\.hc_ffn_base$', r'model.layers.\1.ffn_hc.base'),
+            (r'^layers\.(\d+)\.hc_ffn_scale$', r'model.layers.\1.ffn_hc.scale'),
+            (r'^layers\.(\d+)\.attn\.', r'model.layers.\1.self_attn.'),
+            (r'^layers\.(\d+)\.ffn\.', r'model.layers.\1.mlp.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.attn_sink$', r'\1.sinks'),
+            (r'^(model\.layers\.\d+\.self_attn)\.indexer\.compressor\.norm\.',
+             r'\1.compressor.indexer.kv_norm.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.indexer\.compressor\.ape$',
+             r'\1.compressor.indexer.position_bias'),
+            (r'^(model\.layers\.\d+\.self_attn)\.indexer\.compressor\.',
+             r'\1.compressor.indexer.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.indexer\.', r'\1.compressor.indexer.'),
+            (r'^(model\.layers\.\d+\.self_attn\.compressor\.indexer)\.weights_proj\.',
+             r'\1.scorer.weights_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn\.compressor)\.norm\.', r'\1.kv_norm.'),
+            (r'^(model\.layers\.\d+\.self_attn\.compressor)\.ape$', r'\1.position_bias'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wq_a\.', r'\1.\2.q_a_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wq_b\.', r'\1.\2.q_b_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wkv\.', r'\1.\2.kv_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wgate\.', r'\1.\2.gate_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wo_a\.', r'\1.\2.o_a_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.(.*?)\.wo_b\.', r'\1.\2.o_b_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.wq_a\.', r'\1.q_a_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.wq_b\.', r'\1.q_b_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.wkv\.', r'\1.kv_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.wo_a\.', r'\1.o_a_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.wo_b\.', r'\1.o_b_proj.'),
+            (r'^(model\.layers\.\d+\.self_attn)\.q_norm\.', r'\1.q_a_norm.'),
+            (r'^(model\.layers\.\d+\.mlp\.gate)\.bias$',
+             r'\1.e_score_correction_bias'),
+            (r'^(model\.layers\.\d+\.mlp\.shared_experts)\.w1\.', r'\1.gate_proj.'),
+            (r'^(model\.layers\.\d+\.mlp\.shared_experts)\.w2\.', r'\1.down_proj.'),
+            (r'^(model\.layers\.\d+\.mlp\.shared_experts)\.w3\.', r'\1.up_proj.'),
+        )
+        translated = key
+        for source, target in replacements:
+            translated = re.sub(source, target, translated)
+        if translated == key:
+            return None
+        if is_quantization_scale and translated.endswith('.scale'):
+            translated = translated[:-len('.scale')] + '.weight_scale_inv'
+        return translated
+
+    def _translate_state_dict(self, state_dict):
+        translated = {}
+        for key, value in state_dict.items():
+            target = self._translate_key(key)
+            if target is not None:
+                translated[target] = value
+        return translated
+
+    def load_layer_to_cpu(self, layer_name):
+        state_dict = super().load_layer_to_cpu(layer_name)
+        return self._translate_state_dict(state_dict)
+
+    def _setup_expert_streaming(self):
+        self._expert_streaming = False
+        self._expert_keys = {}
+        self._non_expert_keys = {}
+
+        layer_prefix = self.layer_names_dict['layer_prefix']
+        hooked = 0
+        for idx in self._streamed_indices:
+            layer_name = self.layer_names[idx]
+            if not layer_name.startswith(layer_prefix + '.'):
+                continue
+            checkpoint_name = self._checkpoint_layer_name(layer_name)
+            tensor_sizes = layer_tensor_sizes(self.checkpoint_path, checkpoint_name)
+
+            experts = {}
+            others = []
+            for key in tensor_sizes:
+                match = self._EXPERT_KEY.match(key)
+                if match is None:
+                    others.append(key)
+                    continue
+                expert_idx = int(match.group(2))
+                projection = match.group(3)
+                kind = match.group(4)
+                experts.setdefault(expert_idx, {}).setdefault(projection, {})[kind] = key
+
+            if not experts:
+                continue
+
+            expert_module = self.layers[idx].mlp.experts
+            expert_module._airllm_owner = self
+            expert_module._airllm_layer_idx = idx
+            expert_module.forward = MethodType(_streamed_experts_forward, expert_module)
+            self._expert_keys[idx] = experts
+            self._non_expert_keys[idx] = others
+            self._layer_tensor_sizes[idx] = tensor_sizes
+            hooked += len(experts)
+
+        if hooked:
+            self._expert_streaming = True
+            # GenerationMixin otherwise sees Transformers' default ``grouped_mm`` setting and
+            # temporarily swaps the model to ``batched_mm`` during decode. V4's expert forward is
+            # replaced above and owns its FP4 dispatch, so that swap is both irrelevant and fails
+            # when Transformers tries to restore grouped_mm after generation.
+            self.model.config._experts_implementation_internal = 'eager'
+            print(f"DeepSeek V4 selective expert streaming enabled: {hooked} experts across "
+                  f"{len(self._expert_keys)} layers; only routed experts are read from disk.")
+
+    def _configure_streaming_policy(self):
+        if self.max_vram_gb is None:
+            return ()
+        if self.device.type != 'cuda':
+            raise ValueError('max_vram_gb requires a CUDA device')
+
+        budget_bytes = int(self.max_vram_gb * 1024**3)
+        total_bytes = torch.cuda.get_device_properties(self.device).total_memory
+        if budget_bytes > total_bytes:
+            raise ValueError(
+                f"max_vram_gb={self.max_vram_gb:g} exceeds this device's "
+                f"{total_bytes / 1024**3:.2f} GiB of VRAM"
+            )
+
+        allocated_bytes = torch.cuda.memory_allocated(self.device)
+        resident_bytes = 0
+        largest_streamed_bytes = 0
+        for idx in self._streamed_indices:
+            sizes = self._layer_tensor_sizes.get(idx)
+            if sizes is None:
+                checkpoint_name = self._checkpoint_layer_name(self.layer_names[idx])
+                sizes = layer_tensor_sizes(self.checkpoint_path, checkpoint_name)
+                self._layer_tensor_sizes[idx] = sizes
+            keys = self._non_expert_keys.get(idx, sizes.keys())
+            module_bytes = sum(
+                sizes[key] for key in keys if self._translate_key(key) is not None
+            )
+            resident_bytes += module_bytes
+            largest_streamed_bytes = max(largest_streamed_bytes, module_bytes)
+
+        expert_cache_unit_bytes = 0
+        expert_working_bytes = 0
+        max_cache_size = None
+        for idx, experts in self._expert_keys.items():
+            sizes = self._layer_tensor_sizes[idx]
+            expert_sizes = [
+                sum(
+                    sizes[key]
+                    for projection in parts.values()
+                    for key in projection.values()
+                )
+                for parts in experts.values()
+            ]
+            largest_expert = max(expert_sizes)
+            expert_cache_unit_bytes += largest_expert
+            expert_working_bytes = max(
+                expert_working_bytes,
+                largest_expert * self.config.num_experts_per_tok,
+            )
+            layer_cache_limit = len(experts)
+            max_cache_size = (
+                layer_cache_limit
+                if max_cache_size is None
+                else min(max_cache_size, layer_cache_limit)
+            )
+
+        keep_resident, cache_size, working_bytes, required_bytes = self._choose_vram_policy(
+            budget_bytes=budget_bytes,
+            allocated_bytes=allocated_bytes,
+            resident_bytes=resident_bytes,
+            largest_streamed_bytes=largest_streamed_bytes,
+            expert_working_bytes=expert_working_bytes,
+            expert_cache_unit_bytes=expert_cache_unit_bytes,
+            max_cache_size=max_cache_size or 0,
+        )
+        if required_bytes > budget_bytes:
+            raise ValueError(
+                f"max_vram_gb={self.max_vram_gb:g} is too small; this checkpoint needs an "
+                f"estimated minimum of {required_bytes / 1024**3:.2f} GiB"
+            )
+
+        device_index = self.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        torch.cuda.set_per_process_memory_fraction(budget_bytes / total_bytes, device_index)
+
+        self.expert_cache_size = cache_size
+        mode = 'resident' if keep_resident else 'streamed'
+        print(
+            f"DeepSeek V4 {self.max_vram_gb:g} GiB policy: {mode} ordinary weights, "
+            f"{cache_size} cached experts per layer, "
+            f"{working_bytes / 1024**3:.2f} GiB working headroom."
+        )
+        return self._streamed_indices if keep_resident else ()
+
+    def _load_streamed_layer(self, idx):
+        keys = self._non_expert_keys.get(idx) if self._expert_streaming else None
+        if keys is None:
+            return self.load_layer_to_cpu(self.layer_names[idx])
+        state_dict = load_layer_subset(
+            self.checkpoint_path, self._checkpoint_layer_name(self.layer_names[idx]), keys)
+        return self._translate_state_dict(state_dict)
+
+    def _expert_linear(self, inputs, tensors, projection):
+        weight = tensors[projection]['weight'].to(inputs.device)
+        scale = tensors[projection].get('scale')
+        if scale is None or weight.element_size() > 1:
+            return F.linear(inputs, weight.to(inputs.dtype))
+
+        scale = scale.to(inputs.device)
+        if not hasattr(self, '_fp8_linear'):
+            from transformers.integrations.finegrained_fp8 import (
+                finegrained_fp8_linear,
+                fp8_linear,
+            )
+
+            # The current DeepGEMM integration accepts SM90/SM100 but rejects SM120. Bypass its
+            # exception-driven dispatcher there and call the same Triton fallback directly.
+            is_sm12x = (
+                inputs.device.type == 'cuda'
+                and torch.cuda.get_device_capability(inputs.device)[0] == 12
+            )
+            self._fp8_linear = finegrained_fp8_linear if is_sm12x else fp8_linear
+
+        if weight.dtype == torch.int8:
+            block_size = None
+        else:
+            quantization_config = getattr(self.config, 'quantization_config', None)
+            if isinstance(quantization_config, dict):
+                configured = quantization_config.get('weight_block_size', (128, 128))
+            else:
+                configured = getattr(quantization_config, 'weight_block_size', (128, 128))
+            block_size = tuple(configured)
+        return self._fp8_linear(inputs, weight, scale, block_size=block_size)
+
+    def _run_streamed_experts(self, module, hidden_states, top_k_index, top_k_weights):
+        layer_idx = module._airllm_layer_idx
+        final = torch.zeros_like(hidden_states)
+        single_token = hidden_states.size(0) == 1
+        if single_token:
+            routes = sorted(
+                (int(expert_idx), top_k_pos)
+                for top_k_pos, expert_idx in enumerate(top_k_index[0].tolist())
+                if int(expert_idx) in self._expert_keys[layer_idx]
+            )
+            loaded = [expert_idx for expert_idx, _ in routes]
+        else:
+            with torch.no_grad():
+                hit = torch.unique(top_k_index).tolist()
+            loaded = [int(expert_idx) for expert_idx in hit
+                      if int(expert_idx) in self._expert_keys[layer_idx]]
+        layer_cache = self._expert_cache.setdefault(layer_idx, OrderedDict())
+        missing = [expert_idx for expert_idx in loaded if expert_idx not in layer_cache]
+
+        # Opening a V4 layer shard requires parsing its very large tensor index. Fetch every
+        # routed expert through one handle, then execute them individually to keep the simple
+        # batch-1 kernel path and bounded memory use.
+        keys = [
+            key
+            for expert_idx in missing
+            for projection in self._expert_keys[layer_idx][expert_idx].values()
+            for key in projection.values()
+        ]
+        raw = (
+            load_layer_subset(
+                self.checkpoint_path,
+                self._checkpoint_layer_name(self.layer_names[layer_idx]),
+                keys,
+            )
+            if keys else {}
+        )
+
+        for loaded_pos, expert_idx in enumerate(loaded):
+            tensors = layer_cache.get(expert_idx)
+            if tensors is None:
+                tensors = {
+                    projection: {
+                        kind: raw[key].to(hidden_states.device)
+                        for kind, key in parts.items()
+                    }
+                    for projection, parts in self._expert_keys[layer_idx][expert_idx].items()
+                }
+                if self.expert_cache_size:
+                    layer_cache[expert_idx] = tensors
+            else:
+                layer_cache.move_to_end(expert_idx)
+
+            if single_token:
+                selected = hidden_states
+            else:
+                token_idx, top_k_pos = torch.where(top_k_index == expert_idx)
+                selected = hidden_states[token_idx]
+            gate = self._expert_linear(selected, tensors, 'w1')
+            up = self._expert_linear(selected, tensors, 'w3')
+            if module.limit is not None:
+                gate = gate.clamp(max=module.limit)
+                up = up.clamp(min=-module.limit, max=module.limit)
+            current = self._expert_linear(module.act_fn(gate) * up, tensors, 'w2')
+            if single_token:
+                route_weight = top_k_weights[0, routes[loaded_pos][1]]
+                final.add_((current * route_weight).to(final.dtype))
+            else:
+                current = current * top_k_weights[token_idx, top_k_pos, None]
+                final.index_add_(0, token_idx, current.to(final.dtype))
+            del tensors
+
+        while len(layer_cache) > self.expert_cache_size:
+            layer_cache.popitem(last=False)
+
+        module._airllm_last_experts = loaded
+        return final

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -22,6 +22,7 @@ ARCH_OVERRIDES = {
     "BaiChuanForCausalLM": "AirLLMBaichuan",
     "InternLMForCausalLM": "AirLLMInternLM",
     "KimiK3ForConditionalGeneration": "AirLLMKimiK3",
+    "DeepseekV4ForCausalLM": "AirLLMDeepseekV4",
 }
 
 

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import math
 import os
 import ctypes
 import shutil
@@ -117,6 +118,43 @@ def layer_tensor_names(local_path, layer_name):
     """List the tensors in a layer shard without reading any tensor data."""
     with safe_open(str(Path(local_path) / (layer_name + ".safetensors")), framework="pt") as f:
         return list(f.keys())
+
+
+_SAFETENSORS_DTYPE_BYTES = {
+    'BOOL': 1,
+    'U8': 1,
+    'I8': 1,
+    'F8_E4M3': 1,
+    'F8_E4M3FN': 1,
+    'F8_E5M2': 1,
+    'F8_E8M0': 1,
+    'F8_E8M0FNU': 1,
+    'U16': 2,
+    'I16': 2,
+    'F16': 2,
+    'BF16': 2,
+    'U32': 4,
+    'I32': 4,
+    'F32': 4,
+    'U64': 8,
+    'I64': 8,
+    'F64': 8,
+}
+
+
+def layer_tensor_sizes(local_path, layer_name):
+    """Return each tensor's serialized byte size without reading its data."""
+    sizes = {}
+    with safe_open(str(Path(local_path) / (layer_name + ".safetensors")), framework="pt") as f:
+        for key in f.keys():
+            tensor = f.get_slice(key)
+            dtype = tensor.get_dtype()
+            try:
+                element_size = _SAFETENSORS_DTYPE_BYTES[dtype]
+            except KeyError as exc:
+                raise ValueError(f"Unsupported safetensors dtype {dtype!r} for {key}") from exc
+            sizes[key] = math.prod(tensor.get_shape()) * element_size
+    return sizes
 
 
 def load_layer_subset(local_path, layer_name, keys):
@@ -283,6 +321,8 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
     else:
         n_layers = len(set([int(k[len(layer_names['layer_prefix']):].split('.')[1]) for k in index.keys() if layer_names['layer_prefix'] in k]))
 
+    layer_selectors = {}
+
     if layer_names is None:
         layers = ['model.embed_tokens.'] + [f'model.layers.{i}.' for i in range(n_layers)] + ['model.norm.', 'lm_head.']
     else:
@@ -296,10 +336,24 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         layers = layers + list(layer_names.get('resident', []))
         layers = [l + "." for l in layers]
 
+        # Some native checkpoints flatten a small logical module into several top-level keys
+        # instead of a dotted prefix. ``groups`` gives those keys one normal AirLLM shard without
+        # forcing an adapter to copy or rewrite the rest of the checkpoint.
+        for output_name, selectors in layer_names.get('groups', {}).items():
+            output_layer = output_name + "."
+            layers.append(output_layer)
+            layer_selectors[output_layer] = tuple(selectors)
+
+    def _belongs_to_layer(key, layer):
+        selectors = layer_selectors.get(layer)
+        if selectors is None:
+            return key.startswith(layer)
+        return any(key == selector or key.startswith(selector + '.') for selector in selectors)
+
     # Drop layers that have no weights in the checkpoint. This happens for tied embeddings,
     # where lm_head shares storage with embed_tokens and has no entry of its own. Without this we
     # would try to save an empty shard (which fails) and never detect the split as complete.
-    layers = [l for l in layers if any(k.startswith(l) for k in index.keys())]
+    layers = [l for l in layers if any(_belongs_to_layer(k, l) for k in index.keys())]
 
     # Split in ascending shard order. The loop below only ever walks the shard counter forward, so
     # a module whose weights sit in an earlier shard than its predecessor's would silently be saved
@@ -308,7 +362,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
     # so plain embed -> layers -> norm -> lm_head checkpoints keep their existing order.
     def _last_shard_of(layer):
         nums = [int(v.split('-')[1]) for k, v in index.items()
-                if k.startswith(layer) and '-' in v and len(v.split('-')) > 1]
+                if _belongs_to_layer(k, layer) and '-' in v and len(v.split('-')) > 1]
         return max(nums) if nums else -1
 
     layers.sort(key=_last_shard_of)
@@ -346,11 +400,11 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         for k, v in index.items():
             shard_contents[v].append(k)
         for layer in layers:
-            files = {v for k, v in index.items() if k.startswith(layer)}
+            files = {v for k, v in index.items() if _belongs_to_layer(k, layer)}
             if len(files) != 1:
                 continue
             only_file = next(iter(files))
-            if all(k.startswith(layer) for k in shard_contents[only_file]):
+            if all(_belongs_to_layer(k, layer) for k in shard_contents[only_file]):
                 passthrough[layer] = only_file
 
     if passthrough:
@@ -406,7 +460,8 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
 
         # Optionnally load next shard
         # checking whether after spliting from '-', if second element exists. otherwise it throws errors for single 'model.safetensor' files
-        shards = [int(v.split('-')[1]) for k, v in index.items() if k.startswith(layer) and '-' in v and len(v.split('-')) > 1]
+        shards = [int(v.split('-')[1]) for k, v in index.items()
+                  if _belongs_to_layer(k, layer) and '-' in v and len(v.split('-')) > 1]
         if len(shards) > 0:
             # A layer can span several shards (especially fp8 checkpoints, where each weight has a
             # companion weight_scale_inv tensor). Load *every* shard up to the highest one this layer
@@ -436,7 +491,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                     state_dict.update(load_file(to_load, device='cpu'))
 
         else:
-            shards = [v for k, v in index.items() if k.startswith(layer)]
+            shards = [v for k, v in index.items() if _belongs_to_layer(k, layer)]
             single_modelfile = shards[0]
             to_load = checkpoint_path / single_modelfile
             # check if to_load exist, if not downloaad it...
@@ -450,7 +505,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 state_dict.update(load_file(to_load, device='cpu'))
 
         # Get layer state dict
-        layer_state_dict = dict([(k, v) for k, v in state_dict.items() if k.startswith(layer)])
+        layer_state_dict = {k: v for k, v in state_dict.items() if _belongs_to_layer(k, layer)}
 
         layer_state_dict = compress_layer_state_dict(layer_state_dict, compression)
 

--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -40,6 +40,14 @@ setuptools.setup(
         # 'compressed-tensors' is optional too: only checkpoints stored in that format (Kimi K3's
         # MXFP4 weights) need it, and transformers raises a clear error naming it when it is missing.
     ],
+    extras_require={
+        # Transformers loads its FP4/FP8 CUDA kernels through this package. Keep the range aligned
+        # with the Transformers 5.12 integration; newer kernels releases use an incompatible API.
+        'deepseek-v4': [
+            'transformers>=5.12,<5.13',
+            'kernels>=0.12,<0.13',
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/air_llm/tests/test_deepseek_v4.py
+++ b/air_llm/tests/test_deepseek_v4.py
@@ -1,0 +1,207 @@
+"""DeepSeek V4 native-checkpoint and selective-expert streaming tests."""
+
+import sys
+import tempfile
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers import DeepseekV4Config, DeepseekV4ForCausalLM
+from transformers.core_model_loading import revert_weight_conversion
+
+
+_AIRLLM_DIR = Path(__file__).resolve().parents[1] / 'airllm'
+
+# Exercise the Linux/CUDA code path on macOS without importing the optional MLX backend.
+if 'airllm' not in sys.modules:
+    package = types.ModuleType('airllm')
+    package.__path__ = [str(_AIRLLM_DIR)]
+    sys.modules['airllm'] = package
+
+from airllm import airllm_deepseek_v4 as deepseek_v4_module
+from airllm.airllm_deepseek_v4 import AirLLMDeepseekV4
+from airllm.persist import model_persister as persister_module
+from airllm.persist.safetensor_model_persister import SafetensorModelPersister
+from airllm.utils import layer_tensor_sizes
+
+
+persister_module.model_persister = SafetensorModelPersister()
+
+
+class _TokenizerlessV4(AirLLMDeepseekV4):
+    def get_tokenizer(self, hf_token=None):
+        return None
+
+
+def _tiny_config():
+    return DeepseekV4Config(
+        vocab_size=32,
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=16,
+        q_lora_rank=16,
+        moe_intermediate_size=16,
+        num_experts_per_tok=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        mlp_layer_types=['moe'],
+        layer_types=['heavily_compressed_attention'],
+        sliding_window=8,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        o_groups=2,
+        o_lora_rank=8,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        max_position_embeddings=32,
+        num_nextn_predict_layers=0,
+        partial_rotary_factor=0.5,
+        tie_word_embeddings=False,
+        use_cache=False,
+    )
+
+
+def test_native_key_translation():
+    translate = AirLLMDeepseekV4._translate_key
+    assert translate('embed.weight') == 'model.embed_tokens.weight'
+    assert translate('layers.3.attn.wq_a.weight') == 'model.layers.3.self_attn.q_a_proj.weight'
+    assert translate('layers.3.attn.compressor.indexer.weights_proj.weight') == (
+        'model.layers.3.self_attn.compressor.indexer.scorer.weights_proj.weight')
+    assert translate('layers.3.ffn.gate.bias') == (
+        'model.layers.3.mlp.gate.e_score_correction_bias')
+    assert translate('layers.3.ffn.shared_experts.w1.scale') == (
+        'model.layers.3.mlp.shared_experts.gate_proj.weight_scale_inv')
+    assert translate('layers.3.ffn.experts.17.w1.weight') is None
+
+
+def test_packed_fp4_expert_goes_to_native_kernel_without_cpu_dequantization(monkeypatch):
+    calls = []
+
+    def fake_fp8_linear(inputs, weight, scale, block_size=None):
+        calls.append((weight.dtype, scale.dtype, block_size))
+        return torch.zeros(inputs.shape[0], weight.shape[0], dtype=inputs.dtype)
+
+    monkeypatch.setattr(
+        'transformers.integrations.finegrained_fp8.fp8_linear', fake_fp8_linear)
+    adapter = AirLLMDeepseekV4.__new__(AirLLMDeepseekV4)
+    adapter.config = SimpleNamespace(
+        quantization_config={'weight_block_size': [128, 128]})
+    tensors = {
+        'w1': {
+            'weight': torch.zeros(3, 2, dtype=torch.int8),
+            'scale': torch.ones(3, 1, dtype=torch.uint8),
+        },
+    }
+
+    output = adapter._expert_linear(torch.ones(1, 4), tensors, 'w1')
+
+    assert output.shape == (1, 3)
+    assert calls == [(torch.int8, torch.uint8, None)]
+
+
+def test_layer_tensor_sizes_reads_metadata_without_materializing_weights():
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        save_file(
+            {
+                'bf16': torch.zeros(3, 5, dtype=torch.bfloat16),
+                'int8': torch.zeros(7, dtype=torch.int8),
+            },
+            str(root / 'layer.safetensors'),
+        )
+
+        assert layer_tensor_sizes(root, 'layer') == {'bf16': 30, 'int8': 7}
+
+
+def test_max_vram_policy_prefers_residency_then_spends_remainder_on_cache():
+    gib = 1024**3
+    resident, cache_size, working, required = AirLLMDeepseekV4._choose_vram_policy(
+        budget_bytes=16 * gib,
+        allocated_bytes=gib // 2,
+        resident_bytes=8 * gib,
+        largest_streamed_bytes=gib,
+        expert_working_bytes=gib // 10,
+        expert_cache_unit_bytes=gib // 2,
+        max_cache_size=256,
+    )
+
+    assert resident is True
+    assert cache_size == 11
+    assert working == int(1.6 * gib)
+    assert required < 16 * gib
+
+
+def test_max_vram_policy_streams_when_residency_does_not_fit():
+    gib = 1024**3
+    resident, cache_size, working, required = AirLLMDeepseekV4._choose_vram_policy(
+        budget_bytes=4 * gib,
+        allocated_bytes=gib // 2,
+        resident_bytes=8 * gib,
+        largest_streamed_bytes=gib,
+        expert_working_bytes=gib // 10,
+        expert_cache_unit_bytes=gib // 2,
+        max_cache_size=256,
+    )
+
+    assert resident is False
+    assert cache_size == 2
+    assert working == 2 * gib + gib // 10
+    assert required < 4 * gib
+
+
+def test_tiny_native_checkpoint_matches_transformers_and_batches_routed_expert_read(monkeypatch):
+    torch.manual_seed(7)
+    config = _tiny_config()
+    reference = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.tensor([[1]])
+
+    with torch.no_grad():
+        expected = reference(input_ids, use_cache=False).logits
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        raw_state = revert_weight_conversion(reference.model, reference.model.state_dict())
+        raw_state['head.weight'] = reference.lm_head.weight.detach().clone()
+        save_file(
+            {key: value.detach().contiguous() for key, value in raw_state.items()},
+            str(root / 'model.safetensors'),
+        )
+        config.save_pretrained(root)
+
+        model = _TokenizerlessV4(
+            root,
+            device='cpu',
+            dtype=torch.float32,
+            prefetching=False,
+        )
+        expert_reads = []
+        original_load_subset = deepseek_v4_module.load_layer_subset
+
+        def counted_load_subset(local_path, layer_name, keys):
+            if any('.experts.' in key for key in keys):
+                expert_reads.append(tuple(keys))
+            return original_load_subset(local_path, layer_name, keys)
+
+        monkeypatch.setattr(deepseek_v4_module, 'load_layer_subset', counted_load_subset)
+        with torch.no_grad():
+            actual = model.model(input_ids, use_cache=False).logits
+            cached = model.model(input_ids, use_cache=False).logits
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.testing.assert_close(cached, expected, rtol=0, atol=0)
+        loaded = model.model.model.layers[0].mlp.experts._airllm_last_experts
+        assert len(loaded) == config.num_experts_per_tok
+        assert len(loaded) < config.n_routed_experts
+        assert len(expert_reads) == 2
+        assert model.model.config._experts_implementation == 'eager'
+
+        split = root / 'splitted_model'
+        assert (split / 'hc_head.safetensors').is_file()
+        with safe_open(str(split / 'hc_head.safetensors'), framework='pt') as shard:
+            assert set(shard.keys()) == {'hc_head_fn', 'hc_head_base', 'hc_head_scale'}


### PR DESCRIPTION
## Summary

- add native `DeepseekV4ForCausalLM` loading for `deepseek-ai/DeepSeek-V4-Flash-0731`
- stream only the routed experts from each MoE layer instead of materializing the stacked expert tensors
- add `max_vram_gb` to automatically choose ordinary-weight residency and a bounded per-layer expert cache
- add the `deepseek-v4` install extra, model registration, user documentation, and CPU-only structural tests

## Why

The released V4 checkpoint uses a flat DeepSeek key namespace and stores every routed expert as
separate packed tensors. Transformers builds Hugging Face module names and stacks all experts into
two tensors per layer. Loading those tensors through AirLLM's ordinary whole-layer path therefore
does not map to the native checkpoint and would defeat sparse routing's memory advantage.

The adapter translates the non-expert namespace, keeps expert tensors in their native FP4/FP8
representation, and replaces only the stacked expert forward. Each layer opens its safetensors
shard once per forward and reads the experts selected by the router. The rest of the model continues
to use AirLLM's existing streaming hooks.

`max_vram_gb` reads tensor sizes from safetensors metadata, reserves execution headroom, and spends
the remaining budget on ordinary-weight residency and an LRU expert cache. Without the option, V4
uses the minimum-memory fully streamed path.

## Validation

- 6 V4 tests cover native key translation, packed expert dispatch, metadata-only size accounting,
  both VRAM-policy branches, and exact logits against Transformers on a miniature native-format V4
  checkpoint.
- 8 existing Kimi K3 splitter/regression tests remain green after the base loader changes.
- The exact PR commit completed an end-to-end generation from the released checkpoint under a
  14 GiB allocator cap: `Paris` plus EOS, with 12.777 GiB peak allocated and 12.783 GiB reserved.
- Earlier capped runs exercised all policy tiers on the same checkpoint:

| Budget | Selected policy | Peak reserved | Sustained warm decode |
| ---: | --- | ---: | ---: |
| 4 GiB | stream ordinary weights, cache 3 experts/layer | 3.22 GiB | ~0.62 tokens/s |
| 14 GiB | keep ordinary weights resident, cache 8 experts/layer | 13.06 GiB | ~2.16 tokens/s |
| 40 GiB | keep ordinary weights resident, cache 51 experts/layer | 33.85 GiB | ~3.65 tokens/s |

## Reviewer notes

The memory tiers were enforced with PyTorch allocator caps on one 96 GiB SM120 RTX PRO 6000; they
do not establish kernel compatibility or identical performance on physical 4/16/40 GiB cards.
DeepGEMM currently rejects SM120, so that architecture goes directly to Transformers' Triton
fallback. Long-context behavior has not yet been characterized.
