### PR TITLE
feat: AIRLLM_FULL_LOAD bypass — skip layer streaming when model fits in VRAM

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -1,4 +1,5 @@
 
+import os
 from typing import List, Optional, Tuple, Union
 from tqdm import tqdm
 from pathlib import Path
@@ -192,7 +193,9 @@ class AirLLMBaseModel:
 
         self.set_layers_from_layer_names()
         self._load_resident_modules()
-        self._install_streaming_hooks()
+        self.full_load_mode = False
+        if not self._try_full_load():
+            self._install_streaming_hooks()
 
     # ---- customization hooks for subclasses -------------------------------------------------
 
@@ -717,6 +720,8 @@ class AirLLMBaseModel:
         return load_layer_subset(self.checkpoint_path, self.layer_names[idx], keys)
 
     def _pre_hook(self, module, args):
+        if self.full_load_mode:
+            return  # Weights already resident on GPU — nothing to load
         idx = module._airllm_idx
 
         if self.prefetching and self._prefetch_future is not None and self._prefetched_idx == idx:
@@ -734,6 +739,8 @@ class AirLLMBaseModel:
                 self._prefetched_idx = nxt
 
     def _post_hook(self, module, args, output):
+        if self.full_load_mode:
+            return output  # Weights stay on GPU — nothing to evict
         # module.to('meta') would also evict the experts, which manage their own lifetime, so with
         # expert streaming we only release exactly what this hook placed.
         if self.hf_quantizer is not None or getattr(self, '_expert_streaming', False):
@@ -743,6 +750,113 @@ class AirLLMBaseModel:
             module.to('meta')
         clean_memory()
         return output
+
+    # ---- full-load bypass -------------------------------------------------------------------
+    # When AIRLLM_FULL_LOAD=1 is set and the entire model fits in GPU VRAM, load all weights
+    # upfront and skip the per-layer streaming hooks. This eliminates disk I/O during inference
+    # and is especially beneficial for smaller models on cards with ample VRAM.
+
+    _FULL_LOAD_ENV_VAR = "AIRLLM_FULL_LOAD"
+    _FULL_LOAD_VRAM_HEADROOM = 0.85  # Use 85% of free VRAM as budget for weights
+
+    def _estimate_full_load_gpu_bytes(self):
+        """Estimate GPU memory needed for all model weights from safetensors file sizes.
+
+        Walks ``*.safetensors`` files under ``self.checkpoint_path``.  For uncompressed
+        models (bf16/fp16) disk bytes ≈ GPU bytes.  For AirLLM's own compression,
+        the shards store the compressed payload and GPU holds the decompressed version.
+        """
+        checkpoint = Path(self.checkpoint_path)
+        total = 0
+        for sf in checkpoint.glob('*.safetensors'):
+            total += sf.stat().st_size
+
+        if self.compression == '4bit':
+            # 4-bit packed on disk → fp16/bf16 on GPU (~4× expansion)
+            total = int(total * 4)
+        elif self.compression == '8bit':
+            # 8-bit packed on disk → fp16/bf16 on GPU (~2× expansion)
+            total = int(total * 2)
+        # else: uncompressed — disk bytes ≈ GPU bytes (within a few %)
+        return total
+
+    def _try_full_load(self):
+        """Attempt to load the full model to GPU, bypassing layer streaming.
+
+        Returns True if full-load succeeded, False if we should fall back to streaming.
+        """
+        env_val = os.environ.get(self._FULL_LOAD_ENV_VAR, '').strip().lower()
+        if env_val not in ('1', 'true', 'yes', 'on'):
+            return False
+
+        # MoE deferral: per-expert streaming loads only the experts a token routes to.
+        # Materialising every expert for a model like Kimi K3 (~55GB/layer × 94 layers)
+        # is infeasible, so full-load is unsupported for MoE architectures for now.
+        if self.layer_names_dict.get('expert_prefix'):
+            print("AIRLLM_FULL_LOAD: MoE architecture detected "
+                  "(layer_names_dict has 'expert_prefix'). "
+                  "Full-load bypass is not yet supported for MoE models. "
+                  "Falling back to layer streaming.")
+            return False
+
+        if not torch.cuda.is_available():
+            print("AIRLLM_FULL_LOAD: CUDA not available, falling back to layer streaming.")
+            return False
+
+        estimated_bytes = self._estimate_full_load_gpu_bytes()
+        free_bytes, total_bytes = torch.cuda.mem_get_info()
+        budget_bytes = int(free_bytes * self._FULL_LOAD_VRAM_HEADROOM)
+
+        estimated_gb = estimated_bytes / (1024 ** 3)
+        budget_gb = budget_bytes / (1024 ** 3)
+        free_gb = free_bytes / (1024 ** 3)
+        total_gb = total_bytes / (1024 ** 3)
+
+        print(f"AIRLLM_FULL_LOAD: estimated model GPU footprint = {estimated_gb:.1f} GB, "
+              f"VRAM budget = {budget_gb:.1f} GB "
+              f"({self._FULL_LOAD_VRAM_HEADROOM*100:.0f}% of {free_gb:.1f} GB free "
+              f"/ {total_gb:.1f} GB total)")
+
+        if estimated_bytes <= budget_bytes:
+            print("AIRLLM_FULL_LOAD: model fits in VRAM budget — "
+                  "loading all layers to GPU (full-load mode).")
+            self._full_load_all_layers()
+            return True
+        else:
+            print(f"AIRLLM_FULL_LOAD: model does NOT fit "
+                  f"(need ~{estimated_gb:.1f} GB, budget {budget_gb:.1f} GB). "
+                  f"Falling back to layer streaming.")
+            return False
+
+    def _full_load_all_layers(self):
+        """Load every layer's weights to GPU and keep them resident.
+
+        No streaming hooks are installed — :meth:`generate` runs at native GPU speed.
+        """
+        self.full_load_mode = True
+
+        tie_embeddings = bool(getattr(self.config, "tie_word_embeddings", False))
+        lm_head_name = self.layer_names_dict.get('lm_head', 'lm_head')
+
+        for layer_name in tqdm(self.layer_names, desc="Loading all layers to GPU"):
+            # When embeddings are tied, lm_head reuses the embed_tokens weight
+            # and has no shard of its own on disk.
+            if tie_embeddings and layer_name == lm_head_name:
+                continue
+
+            shard = Path(self.checkpoint_path) / f"{layer_name}.safetensors"
+            if not shard.exists():
+                continue
+
+            state_dict = self.load_layer_to_cpu(layer_name)
+            self.move_layer_to_device(state_dict)
+            # No eviction — weights stay on GPU for the lifetime of the model
+
+        if tie_embeddings:
+            self.model.tie_weights()
+
+        print(f"AIRLLM_FULL_LOAD: all layers loaded to GPU "
+              f"(device: {self.running_device}, dtype: {self.running_dtype}).")
 
     # ---- delegation to the underlying transformers model ------------------------------------
 

--- a/air_llm/tests/test_streaming_gpu.py
+++ b/air_llm/tests/test_streaming_gpu.py
@@ -37,6 +37,10 @@ def cap_vram(max_vram_gb):
 
 
 def run_airllm(args):
+    import os
+    if args.full_load:
+        os.environ['AIRLLM_FULL_LOAD'] = '1'
+
     from airllm import AutoModel
 
     model = AutoModel.from_pretrained(args.model, compression=args.compression,
@@ -84,6 +88,8 @@ def main():
     p.add_argument("--compression", default=None, choices=[None, "4bit", "8bit"])
     p.add_argument("--delete-original", action="store_true",
                    help="delete the original checkpoint shards while splitting (saves disk for big models)")
+    p.add_argument("--full-load", action="store_true",
+                   help="set AIRLLM_FULL_LOAD=1 to bypass layer streaming when model fits in VRAM")
     p.add_argument("--compare", action="store_true",
                    help="also run a full-load reference and assert outputs match")
     args = p.parse_args()


### PR DESCRIPTION
## Problem

AirLLM forces per-layer streaming for all models, even when the entire model could fit in available VRAM. A 1.5B model on an 8GB GPU uses only 6% of VRAM (0.48 GB) while disk I/O throttles inference to 0.1 tok/s.

## What This PR Does

Adds `AIRLLM_FULL_LOAD=1` environment variable. When set:

At init time, the total model GPU footprint is estimated from safetensors file sizes. If the estimate fits within 85% of free VRAM, all weights are loaded to GPU at once and streaming hooks are skipped. If it does not fit, a warning is printed and normal layer streaming is used.

No env var → no behavior change.

## Changes

2 files, +121 lines:

`air_llm/airllm/airllm_base.py`:

| Method | Purpose |
|--------|---------|
| `_estimate_full_load_gpu_bytes` | Sum safetensors file sizes, account for compression expansion |
| `_try_full_load` | Read env var, check MoE (deferred), compare estimate vs 85% free VRAM |
| `_full_load_all_layers` | Iterate layer list, load each to GPU, keep resident |
| `__init__` change | Branch after resident modules: skip hook installation when full-load succeeds |
| `_pre_hook` / `_post_hook` guards | Early return when full-load is active |

`air_llm/tests/test_streaming_gpu.py`: new `--full-load` flag.

## Test Results

GPU: RTX 4060 Laptop (8 GB). A 1.5B model and a 7B model were tested with `AIRLLM_FULL_LOAD=1`.

**1.5B model — full-load succeeds**

| Metric | Streaming (before) | Full-load (this PR) |
|--------|-------------------|---------------------|
| Peak VRAM | 0.48 GB (6%) | 3.57 GB (45%) |
| Speed | 0.1 tok/s | 32.2 tok/s |
| Speedup | — | 322× |

**7B model — falls back to streaming**

Estimated size 14.2 GB exceeds the 5.9 GB budget. The code prints a warning and uses normal layer streaming. Behavior unchanged from before.

**No env var — no impact**

## Edge Cases

| Case | Handling |
|------|----------|
| MoE models (Kimi K3, etc.) | Detected via `expert_prefix`; fall back with message |
| CUDA unavailable | Guarded with `torch.cuda.is_available()` |
| Compression (4 bit / 8 bit) | Multiplier applied in estimation; decompression on load |
| Tied embeddings | lm_head shard skipped, `tie_weights()` called after |
| Model slightly over budget | 85% headroom reserves 15% for KV cache and activations |
