### PR TITLE
fix: avoid eager MLX LlamaForCausalLM import

### DIFF
--- a/air_llm/airllm/airllm_llama_mlx.py
+++ b/air_llm/airllm/airllm_llama_mlx.py
@@ -13,7 +13,7 @@ import mlx.nn as nn
 from sentencepiece import SentencePieceProcessor
 from .persist import ModelPersister
 import psutil
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, AutoModel, GenerationMixin, LlamaForCausalLM, GenerationConfig
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, AutoModel, GenerationMixin, GenerationConfig
 from .utils import clean_memory, load_layer, \
     find_or_create_local_splitted_path
 

--- a/air_llm/tests/test_mlx_import_regression.py
+++ b/air_llm/tests/test_mlx_import_regression.py
@@ -1,0 +1,12 @@
+"""Dependency-free regression test for issue #326."""
+from pathlib import Path
+
+
+SOURCE = Path(__file__).parents[1] / "airllm" / "airllm_llama_mlx.py"
+
+
+def test_mlx_module_does_not_eagerly_import_unused_llama_class():
+    source = SOURCE.read_text(encoding="utf-8")
+    import_lines = [line for line in source.splitlines() if line.startswith("from transformers import")]
+    assert import_lines, "expected the MLX module's transformers import"
+    assert all("LlamaForCausalLM" not in line for line in import_lines)


### PR DESCRIPTION
## Summary

- Remove the unused `LlamaForCausalLM` symbol from the eager Transformers import in the MLX backend.
- Add a dependency-free regression test that prevents the unused import from returning.

The MLX backend is imported on Darwin, so requesting an unused Llama class can pull in Transformers' vision path and expose an unrelated `torchvision::nms` failure. The removed symbol is not referenced elsewhere in the module.

## Testing

- Focused regression test: `1 passed`
- Python syntax compilation: passed
- Mutation check: reintroducing the removed import causes the regression test to fail
- `git diff --check`: passed

The full project suite and macOS/Transformers runtime were not run in this Linux environment.

Fixes #326
