### PR TITLE
fix: critical bugs — unsafe torch.load (RCE), UnboundLocalError crash, thread leak, broken tests

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -744,7 +744,30 @@ class AirLLMBaseModel:
         clean_memory()
         return output
 
+    # ---- lifecycle management ----------------------------------------------------------------
+
+    def close(self):
+        """Shut down the prefetch executor and release background resources.
+
+        Call this when you are done with the model to avoid leaking threads.
+        Safe to call multiple times.
+        """
+        if self._prefetch_future is not None:
+            self._prefetch_future.cancel()
+            self._prefetch_future = None
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None
+
+    def __del__(self):
+        # Safety net: clean up if the user forgot to call close().
+        try:
+            self.close()
+        except Exception:
+            pass
+
     # ---- delegation to the underlying transformers model ------------------------------------
+
 
     def generate(self, *args, **kwargs):
         return self.model.generate(*args, **kwargs)

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -80,7 +80,8 @@ def clean_memory():
     except Exception as ex:
         # maybe platform
         pass
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 def uncompress_layer_state_dict(layer_state_dict):
@@ -196,12 +197,13 @@ def compress_layer_state_dict(layer_state_dict, compression=None):
     return compressed_layer_state_dict if compressed_layer_state_dict is not None else layer_state_dict
 
 def remove_real_and_linked_file(to_delete):
-    if (os.path.realpath(to_delete) != to_delete):
+    targetpath = None
+    if os.path.realpath(to_delete) != to_delete:
         targetpath = os.path.realpath(to_delete)
 
     os.remove(to_delete)
-    if (targetpath):
-         os.remove(targetpath)
+    if targetpath:
+        os.remove(targetpath)
 
 
 
@@ -270,7 +272,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
     elif os.path.exists(checkpoint_path / 'pytorch_model.bin'):
         # single-file torch checkpoint: map every tensor to that one file
         safetensors_format = False
-        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu')
+        single_sd = torch.load(checkpoint_path / 'pytorch_model.bin', map_location='cpu', weights_only=True)
         index = {k: 'pytorch_model.bin' for k in single_sd.keys()}
         del single_sd
     else:
@@ -431,7 +433,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                                                     token=hf_token)
 
                 if not safetensors_format:
-                    state_dict.update(torch.load(to_load, map_location='cpu'))
+                    state_dict.update(torch.load(to_load, map_location='cpu', weights_only=True))
                 else:
                     state_dict.update(load_file(to_load, device='cpu'))
 
@@ -445,7 +447,7 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
                 huggingface_hub.snapshot_download(repo_id, allow_patterns=os.path.basename(to_load),
                                                 token=hf_token)
             if not safetensors_format:
-                state_dict.update(torch.load(to_load, map_location='cpu'))
+                state_dict.update(torch.load(to_load, map_location='cpu', weights_only=True))
             else:
                 state_dict.update(load_file(to_load, device='cpu'))
 

--- a/air_llm/tests/test_automodel.py
+++ b/air_llm/tests/test_automodel.py
@@ -15,17 +15,20 @@ class TestAutoModel(unittest.TestCase):
 
     def test_auto_model_should_return_correct_model(self):
         mapping_dict = {
-            'garage-bAInd/Platypus2-7B': 'AirLLMLlama2',
+            # These architectures have dedicated subclasses in ARCH_OVERRIDES
             'Qwen/Qwen-7B': 'AirLLMQWen',
-            'internlm/internlm-chat-7b': 'AirLLMInternLM',
             'THUDM/chatglm3-6b-base': 'AirLLMChatGLM',
             'baichuan-inc/Baichuan2-7B-Base': 'AirLLMBaichuan',
-            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMMistral',
-            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMMixtral'
+            'internlm/internlm-chat-7b': 'AirLLMInternLM',
+            # Standard architectures now use the generic streaming model
+            'garage-bAInd/Platypus2-7B': 'AirLLMBaseModel',
+            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMBaseModel',
+            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMBaseModel',
         }
 
 
         for k,v in mapping_dict.items():
             module, cls = AutoModel.get_module_class(k)
-            self.assertEqual(cls, v, f"expecting {v}")
+            self.assertEqual(cls, v, f"expecting {v} for {k}, got {cls}")
+
 


### PR DESCRIPTION
## Summary

Deep manual code audit of the entire airllm codebase found **5 real bugs** — a security vulnerability, crash bugs, a resource leak, and broken tests.

---

### Bug 1 — 🔴 CRITICAL: Arbitrary Code Execution via Unsafe 	orch.load

**File:** ir_llm/airllm/utils.py (lines 273, 434, 448)

	orch.load() without weights_only=True uses Python's pickle module, which allows arbitrary code execution. A malicious .bin checkpoint can execute arbitrary Python when loaded — installing malware, exfiltrating data, or creating a reverse shell.

**Fix:** Added weights_only=True to all 3 	orch.load() call sites.

**Ref:** https://pytorch.org/docs/stable/generated/torch.load.html

---

### Bug 2 — 🔴 HIGH: emove_real_and_linked_file() Crashes with UnboundLocalError

**File:** ir_llm/airllm/utils.py (lines 198–204)

\\\python
def remove_real_and_linked_file(to_delete):
    if (os.path.realpath(to_delete) != to_delete):
        targetpath = os.path.realpath(to_delete)  # only assigned inside if
    os.remove(to_delete)
    if (targetpath):      # ← UnboundLocalError when file is NOT a symlink
         os.remove(targetpath)
\\\

When the file is not a symlink, 	argetpath is never assigned, causing UnboundLocalError. This crashes the delete_original=True workflow (critical for 1.5TB+ models like Kimi K3).

**Fix:** Initialize 	argetpath = None before the conditional.

---

### Bug 3 — 🟡 HIGH: ThreadPoolExecutor Resource Leak

**File:** ir_llm/airllm/airllm_base.py (line 175)

The executor for prefetching is created but never shut down — no __del__, close(), or context manager. Each model instance leaks a daemon thread.

**Fix:** Added close() method and __del__ safety net.

---

### Bug 4 — 🟡 MEDIUM: Unit Tests Outdated After Refactor

**File:** ir_llm/tests/test_automodel.py

Tests expect AirLLMLlama2, AirLLMMistral, AirLLMMixtral but these architectures are no longer in ARCH_OVERRIDES — they correctly fall through to AirLLMBaseModel. Tests fail on every run.

**Fix:** Updated expected class names to match current ARCH_OVERRIDES.

---

### Bug 5 — 🟡 MEDIUM: clean_memory() Crashes on Non-CUDA Systems

**File:** ir_llm/airllm/utils.py (line 83)

	orch.cuda.empty_cache() called without checking 	orch.cuda.is_available(). Crashes on CPU-only systems used for checkpoint splitting.

**Fix:** Added 	orch.cuda.is_available() guard.

---

### Files Changed

| File | Changes |
|------|---------|
| ir_llm/airllm/utils.py | Bugs 1, 2, 5 |
| ir_llm/airllm/airllm_base.py | Bug 3 |
| ir_llm/tests/test_automodel.py | Bug 4 |
