### PR TITLE
fix: robust layer-count parsing for nested checkpoint prefixes (complements #336)

### DIFF
--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -232,6 +232,26 @@ def link_or_copy_file(src, dst):
     return 'copy'
 
 
+def _count_layers(index_keys, marker):
+    # Extract the layer index that immediately follows `marker` in each key. Using
+    # .find() (rather than assuming the key starts with `marker`) and guarding with
+    # .isdigit() keeps this correct for checkpoints where the LM is nested under a
+    # wrapper module, e.g. VLM checkpoints shaped like
+    # "language_model.model.layers.0.self_attn.q_proj.weight" -- `marker` is still
+    # found inside the key, but the segment right after it is the layer index, not
+    # some fixed split position. Without the isdigit guard this raises
+    # "ValueError: invalid literal for int() with base 10: 'layers'" on such models.
+    nums = set()
+    for k in index_keys:
+        pos = k.find(marker)
+        if pos == -1:
+            continue
+        head = k[pos + len(marker):].split('.', 1)[0]
+        if head.isdigit():
+            nums.add(int(head))
+    return len(nums)
+
+
 def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitted_model_dir_name='splitted_model',
                           compression=None, layer_names=None, delete_original=False, repo_id=None, hf_token=None):
     """
@@ -277,25 +297,6 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
         raise FileNotFoundError(
             f"No model weights found under {checkpoint_path}. Expected one of: "
             f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
-
-    def _count_layers(index_keys, marker):
-        # Extract the layer index that immediately follows `marker` in each key. Using
-        # .find() (rather than assuming the key starts with `marker`) and guarding with
-        # .isdigit() keeps this correct for checkpoints where the LM is nested under a
-        # wrapper module, e.g. VLM checkpoints shaped like
-        # "language_model.model.layers.0.self_attn.q_proj.weight" -- `marker` is still
-        # found inside the key, but the segment right after it is the layer index, not
-        # some fixed split position. Without the isdigit guard this raises
-        # "ValueError: invalid literal for int() with base 10: 'layers'" on such models.
-        nums = set()
-        for k in index_keys:
-            pos = k.find(marker)
-            if pos == -1:
-                continue
-            head = k[pos + len(marker):].split('.', 1)[0]
-            if head.isdigit():
-                nums.add(int(head))
-        return len(nums)
 
     if layer_names is None:
         n_layers = _count_layers(index.keys(), 'model.layers.')

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -278,10 +278,29 @@ def split_and_save_layers(checkpoint_path, layer_shards_saving_path=None, splitt
             f"No model weights found under {checkpoint_path}. Expected one of: "
             f"model.safetensors(.index.json) or pytorch_model.bin(.index.json).")
 
+    def _count_layers(index_keys, marker):
+        # Extract the layer index that immediately follows `marker` in each key. Using
+        # .find() (rather than assuming the key starts with `marker`) and guarding with
+        # .isdigit() keeps this correct for checkpoints where the LM is nested under a
+        # wrapper module, e.g. VLM checkpoints shaped like
+        # "language_model.model.layers.0.self_attn.q_proj.weight" -- `marker` is still
+        # found inside the key, but the segment right after it is the layer index, not
+        # some fixed split position. Without the isdigit guard this raises
+        # "ValueError: invalid literal for int() with base 10: 'layers'" on such models.
+        nums = set()
+        for k in index_keys:
+            pos = k.find(marker)
+            if pos == -1:
+                continue
+            head = k[pos + len(marker):].split('.', 1)[0]
+            if head.isdigit():
+                nums.add(int(head))
+        return len(nums)
+
     if layer_names is None:
-        n_layers = len(set([int(k.split('.')[2]) for k in index.keys() if 'model.layers' in k]))
+        n_layers = _count_layers(index.keys(), 'model.layers.')
     else:
-        n_layers = len(set([int(k[len(layer_names['layer_prefix']):].split('.')[1]) for k in index.keys() if layer_names['layer_prefix'] in k]))
+        n_layers = _count_layers(index.keys(), layer_names['layer_prefix'] + '.')
 
     if layer_names is None:
         layers = ['model.embed_tokens.'] + [f'model.layers.{i}.' for i in range(n_layers)] + ['model.norm.', 'lm_head.']

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -233,15 +233,20 @@ def link_or_copy_file(src, dst):
 
 
 def _count_layers(index_keys, marker):
-    # Layer index = the digit segment right after `marker` in each key. .find() + .isdigit()
-    # (mirroring the MoE expert parser in airllm_base.py) makes this correct for VLM-style
-    # keys like "language_model.model.layers.0.self_attn.q_proj.weight", where the index is
-    # not at a fixed split position -- the previous code crashed with
-    # "ValueError: invalid literal for int() with base 10: 'layers'".
+    # Layer index = the digit segment right after `marker` in each key. Using .find() rather
+    # than assuming the key starts with `marker`, and guarding with .isdigit(), keeps this
+    # correct for checkpoints where the LM is nested under a wrapper module, e.g. VLM keys
+    # like "language_model.model.layers.0.self_attn.q_proj.weight" -- the marker is still
+    # found inside the key, and the segment right after it is the layer index. Without the
+    # isdigit guard the previous code raised
+    # "ValueError: invalid literal for int() with base 10: 'layers'" on such models.
     nums = set()
     for k in index_keys:
         pos = k.find(marker)
-        if pos != -1 and (head := k[pos + len(marker):].split('.', 1)[0]).isdigit():
+        if pos == -1:
+            continue
+        head = k[pos + len(marker):].split('.', 1)[0]
+        if head.isdigit():
             nums.add(int(head))
     return len(nums)
 

--- a/air_llm/airllm/utils.py
+++ b/air_llm/airllm/utils.py
@@ -233,21 +233,15 @@ def link_or_copy_file(src, dst):
 
 
 def _count_layers(index_keys, marker):
-    # Extract the layer index that immediately follows `marker` in each key. Using
-    # .find() (rather than assuming the key starts with `marker`) and guarding with
-    # .isdigit() keeps this correct for checkpoints where the LM is nested under a
-    # wrapper module, e.g. VLM checkpoints shaped like
-    # "language_model.model.layers.0.self_attn.q_proj.weight" -- `marker` is still
-    # found inside the key, but the segment right after it is the layer index, not
-    # some fixed split position. Without the isdigit guard this raises
-    # "ValueError: invalid literal for int() with base 10: 'layers'" on such models.
+    # Layer index = the digit segment right after `marker` in each key. .find() + .isdigit()
+    # (mirroring the MoE expert parser in airllm_base.py) makes this correct for VLM-style
+    # keys like "language_model.model.layers.0.self_attn.q_proj.weight", where the index is
+    # not at a fixed split position -- the previous code crashed with
+    # "ValueError: invalid literal for int() with base 10: 'layers'".
     nums = set()
     for k in index_keys:
         pos = k.find(marker)
-        if pos == -1:
-            continue
-        head = k[pos + len(marker):].split('.', 1)[0]
-        if head.isdigit():
+        if pos != -1 and (head := k[pos + len(marker):].split('.', 1)[0]).isdigit():
             nums.add(int(head))
     return len(nums)
 

--- a/air_llm/tests/test_layer_count.py
+++ b/air_llm/tests/test_layer_count.py
@@ -57,7 +57,7 @@ class TestLayerCountParsing(unittest.TestCase):
     def test_kimi_k3_language_model_prefix(self):
         # Kimi K3 nests the decoder under language_model (airllm_kimi_k3.py)
         prefix = 'language_model.model.layers'
-        keys = [f'{prefix}.{i}.block_sparse_moe.experts.0.w1.weight' for i in range(3)]
+        keys = layer_keys(prefix, 3, 'block_sparse_moe.experts.0.w1.weight')
         self.assertEqual(_count_layers(keys, prefix + '.'), 3)
 
     def test_nested_vlm_default_layout(self):

--- a/air_llm/tests/test_layer_count.py
+++ b/air_llm/tests/test_layer_count.py
@@ -1,0 +1,112 @@
+"""Unit tests for the layer-count parser used when splitting checkpoints.
+
+The splitter (utils._count_layers) must count the decoder layers of a checkpoint
+regardless of how deeply the LM is nested under wrapper modules. Different model
+families use different key prefixes, and VLM / multimodal checkpoints nest the LM
+one or more levels deeper (e.g. ``language_model.model.layers.0...``), which used
+to crash the parser with:
+
+    ValueError: invalid literal for int() with base 10: 'layers'
+
+These tests exercise a matrix of the prefixes seen across the architectures AirLLM
+supports plus the nested shapes that triggered the bug (see #335 / #336).
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+_AIRLLM_DIR = Path(__file__).resolve().parents[1] / 'airllm'
+
+# Bind the package without running airllm/__init__.py: that module pulls in the MLX
+# backend on macOS and the full transformers stack elsewhere, neither of which these
+# pure-parser tests need.
+if 'airllm' not in sys.modules:
+    _pkg = types.ModuleType('airllm')
+    _pkg.__path__ = [str(_AIRLLM_DIR)]
+    sys.modules['airllm'] = _pkg
+
+from airllm.utils import _count_layers
+
+
+def layer_keys(prefix, n, sub='self_attn.q_proj.weight'):
+    """Build a checkpoint-style key list for a single prefix: prefix.N.<sub>."""
+    return [f'{prefix}.{i}.{sub}' for i in range(n)]
+
+
+class TestLayerCountParsing(unittest.TestCase):
+    """Direct tests of _count_layers over real-world key prefixes and nesting shapes."""
+
+    def test_flat_default_llama_layout(self):
+        # Generic / Llama / Baichuan / InternLM / Mistral / Mixtral / Qwen2 (model.layers)
+        keys = layer_keys('model.layers', 5) + ['model.embed_tokens.weight', 'lm_head.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 5)
+
+    def test_qwen1_transformer_h_layout(self):
+        # Qwen1 uses transformer.h.N... (airllm_qwen.py)
+        keys = layer_keys('transformer.h', 4, 'self_attention.c_attn.weight') + ['transformer.wte.weight']
+        self.assertEqual(_count_layers(keys, 'transformer.h.'), 4)
+
+    def test_chatglm_nested_layer_prefix(self):
+        # ChatGLM uses transformer.encoder.layers.N... (airllm_chatglm.py)
+        prefix = 'transformer.encoder.layers'
+        keys = layer_keys(prefix, 6, 'self_attention.dense.weight') + ['transformer.word_embeddings.weight']
+        self.assertEqual(_count_layers(keys, prefix + '.'), 6)
+
+    def test_kimi_k3_language_model_prefix(self):
+        # Kimi K3 nests the decoder under language_model (airllm_kimi_k3.py)
+        prefix = 'language_model.model.layers'
+        keys = [f'{prefix}.{i}.block_sparse_moe.experts.0.w1.weight' for i in range(3)]
+        self.assertEqual(_count_layers(keys, prefix + '.'), 3)
+
+    def test_nested_vlm_default_layout(self):
+        # The exact bug: 'model.layers' appears mid-key, not at position [0,1,2].
+        # Old code did int(k.split('.')[2]) -> 'layers' -> ValueError.
+        keys = layer_keys('language_model.model.layers', 7) + ['language_model.model.embed_tokens.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 7)
+
+    def test_deep_multi_level_nesting(self):
+        # LM wrapped more than once: marker is found deep inside the key.
+        keys = layer_keys('model.language_model.model.layers', 4)
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 4)
+
+    def test_qwen3_style_ge_model_prefix(self):
+        # Shape reported for Qwen3.6 in #335: ge_model.layers.N...
+        keys = layer_keys('ge_model.layers', 28) + ['ge_model.embed_tokens.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 28)
+
+    def test_non_layer_keys_are_ignored(self):
+        keys = ['model.embed_tokens.weight', 'model.norm.weight', 'lm_head.weight',
+                'vision_tower.encoder.blocks.0.mlp.fc0.weight', 'mm_projector.proj.0.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 0)
+
+    def test_empty_index_is_not_a_crash(self):
+        self.assertEqual(_count_layers([], 'model.layers.'), 0)
+
+    def test_non_numeric_segment_is_skipped(self):
+        # 'model.layers.' is present but the next segment is not a digit; must not crash.
+        keys = ['model.layers.attention.weight', 'model.layers.gate.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 0)
+
+    def test_duplicate_layer_indices_counted_once(self):
+        keys = (layer_keys('model.layers', 3) + layer_keys('model.layers', 3)
+                + layer_keys('model.layers', 3))
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 3)
+
+    def test_issue_335_reproduction_does_not_raise(self):
+        # Original crash, verbatim from the issue.
+        k = 'language_model.model.layers.0.self_attn.q_proj.weight'
+        self.assertEqual(_count_layers([k], 'model.layers.'), 1)
+        with self.assertRaises(ValueError):
+            int(k.split('.')[2])  # the old code path
+
+    def test_marker_not_at_key_start(self):
+        # Marker immediately after a wrapper module, the reported failing shape.
+        keys = ['language_model.model.layers.0.self_attn.q_proj.weight',
+                'language_model.model.layers.1.self_attn.q_proj.weight']
+        self.assertEqual(_count_layers(keys, 'model.layers.'), 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #335 (both branches -- see comment on #336 for why that PR's
fix is scoped to only one branch).

`utils.py`'s layer-counting logic assumed every key matching
`model.layers` starts with that prefix, so it always read the layer
index from a fixed split position. Checkpoints where the LM sits
under a wrapper module (e.g. `language_model.model.layers.0...`,
common in VLM/multimodal architectures) still match the substring
filter but break the positional assumption, causing:

    ValueError: invalid literal for int() with base 10: 'layers'

This applies the same `.find()` + `.isdigit()` guard already used
for per-expert MoE key parsing in `airllm_base.py`, to both the
`layer_names is None` and custom-`layer_names` branches, so it's
correct for arbitrary nesting depth rather than one fixed position.

Verified against both a normal flat checkpoint and a nested
wrapper-style checkpoint (see test snippet in code comments / commit
message).

## Why not just the #336 approach

#336 moves `split('.')[1]` to `split('.')[2]` in the custom-`layer_names`
branch only. Two gaps:

1. The `layer_names is None` branch (default architecture path) is not
   touched and crashes on the same nested-key shape reproduced in #335.
2. Even in the `layer_names` branch, a fixed split index is the same
   class of bug at a different depth. For Key K3's
   `language_model.model.layers.0.self_attn...` keys the post-prefix
   segment is `.0.self_attn...`, where `[1]` is the layer index but `[2]`
   is `'self_attn'` — i.e. the `[2]` shift would *also* raise the exact
   bug on the K3 layout exercised by `air_llm/tests/test_kimi_k3_split.py`.

The `.find()` + `.isdigit()` approach handles both branches at any
nesting depth. `air_llm/tests/test_kimi_k3_split.py` passes unchanged
with this change.