### PR TITLE
Don't use per-expert streaming when shards are compressed

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -716,6 +716,15 @@ class AirLLMBaseModel:
             return
         if type(ModelPersister.get_model_persister()).__name__ != 'SafetensorModelPersister':
             return
+        if self.compression is not None:
+            # Per-expert loading reads tensors straight out of the shard with load_layer_subset(),
+            # which -- unlike load_layer() -- does not run uncompress_layer_state_dict(). With
+            # compression on, the shard holds a quantized payload plus companion .4bit./.8bit.
+            # quant-state tensors, so streaming subsets of it would hand still-quantized weights to
+            # move_layer_to_device(). Fall back to whole-layer streaming, which does decompress.
+            print("per-expert streaming is not supported together with compression for now; "
+                  "streaming whole layers instead.")
+            return
 
         layer_prefix = self.layer_names_dict['layer_prefix']
         hooked = 0

--- a/air_llm/tests/test_expert_streaming_compression.py
+++ b/air_llm/tests/test_expert_streaming_compression.py
@@ -1,0 +1,98 @@
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from airllm.airllm_base import AirLLMBaseModel
+from airllm.utils import load_layer_subset
+
+
+class _Expert(nn.Module):
+    pass
+
+
+class _MoE(nn.Module):
+    def __init__(self, n):
+        super().__init__()
+        self.experts = nn.ModuleList([_Expert() for _ in range(n)])
+
+
+class _Layer(nn.Module):
+    def __init__(self, n):
+        super().__init__()
+        self.block_sparse_moe = _MoE(n)
+
+
+class TestExpertStreamingCompressionGuard(unittest.TestCase):
+    """
+    Per-expert streaming reads tensors out of a shard with load_layer_subset(), which -- unlike
+    load_layer() -- never runs uncompress_layer_state_dict(). So it must not engage when the shards
+    are compressed, or still-quantized weights reach move_layer_to_device().
+    """
+
+    LAYER = 'language_model.model.layers.0'
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _write_shard(self, compressed):
+        """Write a layer shard holding two experts, optionally in airllm's compressed layout."""
+        sd = {}
+        for e in (0, 1):
+            base = f'{self.LAYER}.block_sparse_moe.experts.{e}.w1.weight'
+            if compressed:
+                sd[base] = torch.zeros(64, dtype=torch.uint8)
+                sd[base + '.4bit.absmax'] = torch.zeros(4)
+            else:
+                sd[base] = torch.zeros(8, 8)
+        sd[f'{self.LAYER}.self_attn.q_proj.weight'] = torch.zeros(8, 8)
+        save_file(sd, f'{self.tmpdir.name}/{self.LAYER}.safetensors')
+
+    def _make_obj(self, compression):
+        # Skip the heavy __init__; _setup_expert_streaming only needs these attributes.
+        obj = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        obj.compression = compression
+        obj.layer_names_dict = {'layer_prefix': 'language_model.model.layers',
+                                'expert_prefix': 'block_sparse_moe.experts'}
+        obj.layer_names = ['embed', self.LAYER, 'norm']
+        obj._streamed_indices = [1]
+        obj.checkpoint_path = self.tmpdir.name
+        obj.layers = [None, _Layer(2), None]
+        return obj
+
+    def test_expert_streaming_engages_without_compression(self):
+        # Control: proves the fixture really does enable expert streaming, so the guard test below
+        # is meaningful rather than passing for an unrelated reason.
+        self._write_shard(compressed=False)
+        obj = self._make_obj(None)
+        obj._setup_expert_streaming()
+        self.assertTrue(obj._expert_streaming)
+        self.assertEqual(sorted(obj._expert_keys[1]), [0, 1])
+
+    def test_expert_streaming_disabled_when_compression_is_on(self):
+        for compression in ('4bit', '8bit'):
+            with self.subTest(compression=compression):
+                self._write_shard(compressed=True)
+                obj = self._make_obj(compression)
+                obj._setup_expert_streaming()
+                self.assertFalse(obj._expert_streaming,
+                                 f"expert streaming must stay off with compression={compression}")
+                self.assertEqual(obj._expert_keys, {})
+                self.assertEqual(obj._non_expert_keys, {})
+
+    def test_load_layer_subset_does_not_decompress(self):
+        # Documents *why* the guard is needed.
+        self._write_shard(compressed=True)
+        base = f'{self.LAYER}.block_sparse_moe.experts.0.w1.weight'
+        got = load_layer_subset(self.tmpdir.name, self.LAYER, [base, base + '.4bit.absmax'])
+        self.assertEqual(got[base].dtype, torch.uint8)     # never dequantized
+        self.assertIn(base + '.4bit.absmax', got)          # quant state still present
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Skip per-expert streaming when the layer shards are compressed, so still-quantized weights can't reach `move_layer_to_device()`.

## Why

Per-expert streaming reads tensors straight out of a shard with `load_layer_subset()`. That function — unlike `load_layer()` — never runs `uncompress_layer_state_dict()`:

```python
# utils.py — load_layer() decompresses:
to_return = uncompress_layer_state_dict(layer_state_dict)

# utils.py — load_layer_subset() does not:
with safe_open(...) as f:
    for k in keys:
        out[k] = f.get_tensor(k)
```

With `compression='4bit'/'8bit'` the shard holds a quantized payload plus companion `.4bit.`/`.8bit.` quant-state tensors. Both users of `load_layer_subset()` are affected — `_expert_pre_hook()` for the experts, and `_load_streamed_layer()` for the non-expert remainder — so the layer's weights would be placed without a dequantization step.

Verified the loader side directly on a synthetic compressed shard: `load_layer_subset()` returns the `uint8` payload unchanged, with `...w1.weight.4bit.absmax` sitting alongside it.

## Fix

Guard `_setup_expert_streaming()` the same way prefetching is already guarded a few lines up:

```python
if self.compression is not None:
    print("per-expert streaming is not supported together with compression for now; "
          "streaming whole layers instead.")
    return
```

Compression then falls back to whole-layer streaming, which does decompress. Only architectures declaring `expert_prefix` are affected — currently Kimi K3.

## Testing

`python -m pytest air_llm/tests/test_expert_streaming_compression.py` — 3 tests + 2 subtests, offline (no GPU, no network), all pass:

- **control**: without compression the fixture *does* enable expert streaming — so the guard assertion below isn't vacuous
- the guard holds for both `4bit` and `8bit`
- `load_layer_subset()` demonstrably does not decompress

I confirmed the guard test fails without the fix (`AssertionError: True is not false: expert streaming must stay off with compression=4bit`). Worth mentioning because my first version of that test passed either way — it was bailing early for an unrelated reason, and only building a real `nn.ModuleList` fixture plus the control case made it meaningful.

## Scope / honesty

This is a **latent inconsistency, not a reproduced end-to-end failure.** The only architecture with `expert_prefix` today is Kimi K3, whose MXFP4 weights would likely fail inside `compress_layer_state_dict()` at split time before inference is reached, so I could not get a real run to the broken path — and I have no GPU here in any case. I'm flagging it rather than overselling it: the guard is two lines, matches existing precedent, and removes a trap for the next architecture that declares `expert_prefix`.

Happy to close this if you'd rather leave the interaction unguarded for now.
