### PR TITLE
feat: support prequantized BitsAndBytes streaming with Transformers 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 airllm.egg-info
 build
 dist
+models/
 __pycache__
 # Package README is generated from the top-level README.md at build time
 air_llm/README.md

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -426,7 +426,7 @@ class AirLLMBaseModel:
         else:
             state_dict = load_layer_output
 
-        if self.prefetching and torch.cuda.is_available():
+        if self.prefetching and self.device.type == 'cuda' and torch.cuda.is_available():
             # pin_memory() returns a pinned copy rather than pinning in place, so the result has to
             # be kept for the faster host->device copy to actually happen. Pinned memory can't be
             # paged out, so we only spend it on layers small enough to be safe: a frontier MoE
@@ -591,8 +591,7 @@ class AirLLMBaseModel:
             if self.hf_quantizer is not None and self._needs_quantization(param_name):
                 # On-the-fly-quantizing schemes (e.g. bitsandbytes) reconstruct the param from the
                 # weight plus companion quant-state tensors carried in state_dict.
-                self.hf_quantizer.create_quantized_param(self.model, state_dict[param_name], param_name,
-                                                         self.running_device, state_dict)
+                self._create_quantized_param(param_name, state_dict)
             else:
                 # Normal load. Only ordinary high-precision tensors get cast to the runtime dtype;
                 # pre-quantized payloads must be placed verbatim (see _should_load_verbatim).
@@ -605,6 +604,63 @@ class AirLLMBaseModel:
                                                 value=value, dtype=self.running_dtype)
             moved.append(param_name)
         return moved
+
+    def _create_quantized_param(self, param_name, state_dict):
+        """Materialise one pre-quantized parameter across Transformers API generations.
+
+        Transformers 4 exposed ``create_quantized_param`` directly on each quantizer. Transformers
+        5 replaced it with weight-conversion operations. AirLLM loads one layer outside the normal
+        ``from_pretrained`` pipeline, so it must invoke the equivalent conversion itself.
+        """
+        if hasattr(self.hf_quantizer, 'create_quantized_param'):
+            self.hf_quantizer.create_quantized_param(
+                self.model,
+                state_dict[param_name],
+                param_name,
+                self.running_device,
+                state_dict,
+            )
+            return
+
+        get_conversions = getattr(self.hf_quantizer, 'get_weight_conversions', None)
+        if get_conversions is None:
+            raise RuntimeError(
+                f"{type(self.hf_quantizer).__name__} cannot materialise streamed quantized weights: "
+                "neither create_quantized_param nor get_weight_conversions is available."
+            )
+
+        converters = get_conversions()
+        converter = next((item for item in converters
+                          if 'weight' in getattr(item, 'target_patterns', ())), None)
+        if converter is None or not getattr(converter, 'operations', None):
+            raise RuntimeError(
+                f"No weight deserializer was provided by {type(self.hf_quantizer).__name__}."
+            )
+
+        module_path, _, tensor_name = param_name.rpartition('.')
+        local_state = {}
+        for key, value in state_dict.items():
+            if key == param_name or key.startswith(param_name + '.'):
+                relative_name = key[len(module_path) + 1:]
+                local_state[relative_name] = value.to(self.running_device)
+
+        converted = local_state
+        for operation in converter.operations:
+            converted = operation.convert(
+                converted,
+                full_layer_name=param_name,
+                model=self.model,
+                config=self.config,
+            )
+
+        value = converted.get(tensor_name)
+        if value is None:
+            raise RuntimeError(
+                f"Quantized deserializer for {param_name} returned {tuple(converted)}, "
+                f"expected {tensor_name!r}."
+            )
+        module = self.model.get_submodule(module_path) if module_path else self.model
+        module._parameters[tensor_name] = value
 
     # Suffixes of the companion tensors that pre-quantized checkpoints ship alongside a weight
     # (fp8 block scales, compressed-tensors/MXFP4 packed payloads and their scales, GPTQ indices).
@@ -639,10 +695,24 @@ class AirLLMBaseModel:
         for param_name in state_dict.keys():
             # bitsandbytes stores a weight plus companion quant-state tensors named
             # "<weight>.4bit.*" / "<weight>.8bit.*"; those are reconstructed together via
-            # create_quantized_param, so collapse them down to the base weight name. Everything
-            # else (including fp8 weight + weight_scale_inv pairs) is kept as distinct params.
+            # create_quantized_param, so collapse them down to the base weight name. Hugging Face
+            # pre-quantized checkpoints use a second spelling: ``<weight>.absmax``,
+            # ``<weight>.quant_map`` and ``<weight>.quant_state.bitsandbytes__nf4`` (plus nested
+            # variants). Those are metadata for the same weight, not model parameters; passing one
+            # to AutoHfQuantizer makes Transformers try to resolve ``weight`` as a submodule.
+            # Everything else (including fp8 weight + weight_scale_inv pairs) stays distinct.
             if '.4bit.' in param_name or '.8bit.' in param_name:
                 base = param_name.split('.4bit.')[0].split('.8bit.')[0]
+                if base not in names:
+                    names.append(base)
+            elif any(marker in param_name for marker in (
+                    '.weight.absmax',
+                    '.weight.nested_absmax',
+                    '.weight.nested_quant_map',
+                    '.weight.quant_map',
+                    '.weight.quant_state.bitsandbytes__',
+            )):
+                base = param_name[:param_name.index('.weight.') + len('.weight')]
                 if base not in names:
                     names.append(base)
             elif param_name not in names:

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -82,7 +82,8 @@ class AirLLMBaseModel:
 
     def __init__(self, model_local_path_or_repo_id, device="cuda:0", dtype=None, max_seq_len=512,
                  layer_shards_saving_path=None, profiling_mode=False, compression=None,
-                 hf_token=None, prefetching=True, delete_original=False):
+                 hf_token=None, prefetching=True, delete_original=False,
+                 load_resident_modules=True):
         """
         Parameters
         ----------
@@ -108,6 +109,10 @@ class AirLLMBaseModel:
             overlap the next layer's disk load with the current layer's compute
         delete_original: bool, optional
             delete the original downloaded checkpoint after splitting to save disk space
+        load_resident_modules: bool, optional
+            load non-streamed modules such as a multimodal vision tower, by default True. Set this
+            to False for text-only inference when those modules would otherwise waste VRAM. Inputs
+            that need a skipped module will fail until the model is recreated with this enabled.
         """
 
         self.profiling_mode = profiling_mode
@@ -124,6 +129,7 @@ class AirLLMBaseModel:
 
         self.compression = compression
         self.hf_token = hf_token
+        self.load_resident_modules = load_resident_modules
 
         restore_relocated_transformers_symbols()
 
@@ -727,6 +733,12 @@ class AirLLMBaseModel:
         the meta device and fail the moment they run. They are small (well under a GB), so we load
         them once and leave them resident.
         """
+        if not self.load_resident_modules:
+            resident = self.layer_names_dict.get('resident', [])
+            if resident:
+                print(f"text-only mode: leaving resident modules on meta: {', '.join(resident)}")
+            return
+
         for name in self.layer_names_dict.get('resident', []):
             try:
                 state_dict = self.load_layer_to_cpu(name)

--- a/air_llm/airllm/airllm_qwen3_5.py
+++ b/air_llm/airllm/airllm_qwen3_5.py
@@ -10,8 +10,8 @@ class AirLLMQwen3_5(AirLLMBaseModel):
 
     Transformers ignores the checkpoint's ``mtp.*`` Multi-Token Prediction head
     (``_keys_to_ignore_on_load_unexpected``), so we do not stream or load it. The vision tower is
-    kept resident: text-only ``generate()`` never runs it, but leaving it on meta would crash the
-    moment a caller passes ``pixel_values``.
+    kept resident by default. On a small GPU, pass ``load_resident_modules=False`` for text-only
+    generation; image/video inputs then remain unavailable because the tower stays on ``meta``.
 
     Needs transformers 5.8+ (the class is in-tree; this repo ships no remote modeling code).
     Optional CUDA kernels ``fla`` / ``causal-conv1d`` speed up DeltaNet; transformers falls back

--- a/air_llm/examples/benchmark_prequantized.py
+++ b/air_llm/examples/benchmark_prequantized.py
@@ -24,8 +24,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--device", default="cpu")
     parser.add_argument("--max-new-tokens", type=int, default=2)
     parser.add_argument("--max-seq-len", type=int, default=64)
+    parser.add_argument(
+        "--prompt",
+        default="Answer with one word: what color is a clear daytime sky?",
+    )
+    parser.add_argument("--chat-template", action="store_true")
+    parser.add_argument(
+        "--disable-thinking",
+        action="store_true",
+        help="pass enable_thinking=False to the model's chat template",
+    )
     parser.add_argument("--shard-dir", type=Path)
     parser.add_argument("--no-prefetch", action="store_true")
+    parser.add_argument(
+        "--text-only",
+        action="store_true",
+        help="leave multimodal resident modules (for example a vision tower) on meta",
+    )
     return parser.parse_args()
 
 
@@ -45,6 +60,7 @@ def main() -> None:
             layer_shards_saving_path=str(shard_dir),
             profiling_mode=True,
             prefetching=not args.no_prefetch,
+            load_resident_modules=not args.text_only,
         )
         tokenizer = model.tokenizer
     else:
@@ -57,15 +73,30 @@ def main() -> None:
         model.eval()
     load_seconds = time.perf_counter() - started
 
-    prompt = "Answer with one word: what color is a clear daytime sky?"
-    encoded = tokenizer(
-        prompt,
-        return_tensors="pt",
-        truncation=True,
-        max_length=args.max_seq_len,
-        padding=False,
-    )
+    if args.chat_template:
+        template_kwargs = {"enable_thinking": False} if args.disable_thinking else {}
+        encoded = tokenizer.apply_chat_template(
+            [{"role": "user", "content": args.prompt}],
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            truncation=True,
+            max_length=args.max_seq_len,
+            **template_kwargs,
+        )
+    else:
+        encoded = tokenizer(
+            args.prompt,
+            return_tensors="pt",
+            truncation=True,
+            max_length=args.max_seq_len,
+            padding=False,
+        )
     input_ids = encoded["input_ids"].to(args.device)
+    attention_mask = encoded.get("attention_mask")
+    if attention_mask is not None:
+        attention_mask = attention_mask.to(args.device)
 
     if using_cuda:
         torch.cuda.reset_peak_memory_stats()
@@ -74,6 +105,7 @@ def main() -> None:
     started = time.perf_counter()
     output = model.generate(
         input_ids,
+        attention_mask=attention_mask,
         max_new_tokens=args.max_new_tokens,
         do_sample=False,
         use_cache=True,
@@ -95,6 +127,9 @@ def main() -> None:
         "tokens_per_second": round(generated_tokens / generation_seconds, 4),
         "peak_process_rss_mib": round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024, 1),
         "output": tokenizer.decode(sequences[0], skip_special_tokens=True),
+        "generated_text": tokenizer.decode(
+            sequences[0, input_ids.shape[-1]:], skip_special_tokens=True
+        ),
     }
     if args.engine == "airllm" and getattr(model, "profiler", None) is not None:
         result["profile_seconds"] = {

--- a/air_llm/examples/benchmark_prequantized.py
+++ b/air_llm/examples/benchmark_prequantized.py
@@ -1,0 +1,111 @@
+"""Smoke-test and benchmark a pre-quantized Hugging Face checkpoint with AirLLM."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import resource
+import time
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from airllm import AutoModel
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        default="unsloth/Qwen3-0.6B-unsloth-bnb-4bit",
+    )
+    parser.add_argument("--engine", choices=("airllm", "resident"), default="airllm")
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--max-new-tokens", type=int, default=2)
+    parser.add_argument("--max-seq-len", type=int, default=64)
+    parser.add_argument("--shard-dir", type=Path)
+    parser.add_argument("--no-prefetch", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    using_cuda = torch.device(args.device).type == "cuda"
+    started = time.perf_counter()
+    if args.engine == "airllm":
+        shard_dir = args.shard_dir
+        if shard_dir is None:
+            shard_dir = Path("models/airllm-shards") / args.model.replace("/", "--")
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        model = AutoModel.from_pretrained(
+            args.model,
+            device=args.device,
+            max_seq_len=args.max_seq_len,
+            layer_shards_saving_path=str(shard_dir),
+            profiling_mode=True,
+            prefetching=not args.no_prefetch,
+        )
+        tokenizer = model.tokenizer
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(args.model)
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model,
+            device_map={"": args.device},
+            low_cpu_mem_usage=True,
+        )
+        model.eval()
+    load_seconds = time.perf_counter() - started
+
+    prompt = "Answer with one word: what color is a clear daytime sky?"
+    encoded = tokenizer(
+        prompt,
+        return_tensors="pt",
+        truncation=True,
+        max_length=args.max_seq_len,
+        padding=False,
+    )
+    input_ids = encoded["input_ids"].to(args.device)
+
+    if using_cuda:
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+
+    started = time.perf_counter()
+    output = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        use_cache=True,
+    )
+    if using_cuda:
+        torch.cuda.synchronize()
+    generation_seconds = time.perf_counter() - started
+
+    sequences = output.sequences if hasattr(output, "sequences") else output
+    generated_tokens = sequences.shape[-1] - input_ids.shape[-1]
+    result = {
+        "model": args.model,
+        "engine": args.engine,
+        "device": args.device,
+        "prefetch": not args.no_prefetch,
+        "load_seconds": round(load_seconds, 3),
+        "generation_seconds": round(generation_seconds, 3),
+        "generated_tokens": generated_tokens,
+        "tokens_per_second": round(generated_tokens / generation_seconds, 4),
+        "peak_process_rss_mib": round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024, 1),
+        "output": tokenizer.decode(sequences[0], skip_special_tokens=True),
+    }
+    if args.engine == "airllm" and getattr(model, "profiler", None) is not None:
+        result["profile_seconds"] = {
+            name: round(sum(samples), 3)
+            for name, samples in model.profiler.profiling_time_dict.items()
+        }
+    if using_cuda:
+        result["peak_accelerator_mib"] = round(torch.cuda.max_memory_allocated() / 1024**2, 1)
+
+    print("AIRLLM_BENCHMARK=" + json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/tests/test_prequantized_bnb.py
+++ b/air_llm/tests/test_prequantized_bnb.py
@@ -1,0 +1,75 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from airllm.airllm_base import AirLLMBaseModel
+
+
+class TestPrequantizedBitsAndBytes(unittest.TestCase):
+    def test_quantization_state_keys_collapse_to_weight(self):
+        state_dict = {
+            'model.layers.0.mlp.gate_proj.weight': object(),
+            'model.layers.0.mlp.gate_proj.weight.absmax': object(),
+            'model.layers.0.mlp.gate_proj.weight.nested_absmax': object(),
+            'model.layers.0.mlp.gate_proj.weight.nested_quant_map': object(),
+            'model.layers.0.mlp.gate_proj.weight.quant_map': object(),
+            'model.layers.0.mlp.gate_proj.weight.quant_state.bitsandbytes__nf4': object(),
+            'model.layers.0.input_layernorm.weight': object(),
+        }
+
+        model = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        self.assertEqual(
+            model._param_names_from_state_dict(state_dict),
+            [
+                'model.layers.0.mlp.gate_proj.weight',
+                'model.layers.0.input_layernorm.weight',
+            ],
+        )
+
+    def test_transformers_5_weight_conversion_api(self):
+        class FakeOperation:
+            def __init__(self):
+                self.received = None
+
+            def convert(self, state, **kwargs):
+                self.received = (state, kwargs)
+                return {
+                    'weight': torch.nn.Parameter(
+                        torch.tensor([[7.0]]),
+                        requires_grad=False,
+                    ),
+                }
+
+        operation = FakeOperation()
+        quantizer = SimpleNamespace(
+            get_weight_conversions=lambda: [
+                SimpleNamespace(target_patterns=('weight',), operations=(operation,)),
+            ],
+        )
+
+        model = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        model.hf_quantizer = quantizer
+        model.running_device = 'cpu'
+        model.model = torch.nn.Module()
+        model.model.linear = torch.nn.Linear(1, 1, bias=False)
+        model.config = SimpleNamespace()
+
+        model._create_quantized_param(
+            'linear.weight',
+            {
+                'linear.weight': torch.tensor([[1]], dtype=torch.uint8),
+                'linear.weight.absmax': torch.tensor([2.0]),
+            },
+        )
+
+        state, kwargs = operation.received
+        self.assertEqual(set(state), {'weight', 'weight.absmax'})
+        self.assertEqual(kwargs['full_layer_name'], 'linear.weight')
+        self.assertIs(kwargs['model'], model.model)
+        self.assertIs(kwargs['config'], model.config)
+        torch.testing.assert_close(model.model.linear.weight, torch.tensor([[7.0]]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/air_llm/tests/test_qwen3_8_split.py
+++ b/air_llm/tests/test_qwen3_8_split.py
@@ -14,6 +14,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import Mock
 
 import torch
 from safetensors.torch import save_file, load_file
@@ -31,6 +32,7 @@ from airllm.persist.safetensor_model_persister import SafetensorModelPersister
 _persister_mod.model_persister = SafetensorModelPersister()
 
 from airllm.utils import split_and_save_layers
+from airllm.airllm_base import AirLLMBaseModel
 
 N_LAYERS = 4
 LAYER_PREFIX = "model.language_model.layers"
@@ -160,6 +162,16 @@ class TestQwen38Split(unittest.TestCase):
             dst = self._split_file(module)
             self.assertNotIn(os.stat(dst).st_ino, src_inodes,
                              f"{module} was linked, but this layout should be copied")
+
+    def test_text_only_mode_does_not_materialize_resident_vision_tower(self):
+        model = AirLLMBaseModel.__new__(AirLLMBaseModel)
+        model.load_resident_modules = False
+        model.layer_names_dict = {'resident': ['model.visual']}
+        model.load_layer_to_cpu = Mock()
+
+        model._load_resident_modules()
+
+        model.load_layer_to_cpu.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds support for streaming Hugging Face checkpoints that are already quantized with BitsAndBytes, including compatibility with the Transformers 5
quantizer API.

It also adds an opt-in text-only mode for multimodal models, allowing checkpoints such as Qwen3.8-27B NF4 to run below 3 GB VRAM by leaving the unused
vision tower on the `meta` device.

## What changed

- Recognize BitsAndBytes quantization metadata as companion state rather than model parameters.
- Support both:
  - Legacy `create_quantized_param`.
  - Transformers 5 `get_weight_conversions`.
- Avoid CUDA pinning checks on CPU execution paths.
- Add `load_resident_modules=False` for low-VRAM text-only inference.
- Add benchmark options for:
  - Model, device, prompt, and shard directory.
  - AirLLM versus resident inference.
  - Prefetching.
  - Chat templates and disabled thinking.
  - Text-only multimodal execution.
- Report generated text, throughput, process RSS, accelerator memory, and loading profiles as JSON.
- Document an isolated ROCm setup for the Radeon RX 6400.
- Add regression coverage for BnB metadata, Transformers 5 conversion, and text-only resident-module handling.

## Motivation

AirLLM previously interpreted BnB tensors such as `weight.absmax`,
`weight.quant_map`, and `weight.quant_state.bitsandbytes__nf4` as independent
model parameters. This caused streamed prequantized checkpoints to fail during
module resolution.

Transformers 5 also removed the older direct quantized-parameter creation API,
requiring AirLLM to invoke the newer weight-conversion operations.

For multimodal checkpoints, keeping an unused BF16 vision tower resident can
consume enough VRAM to prevent the streamed output head from loading. The new
text-only mode makes that memory optional while preserving the existing default
behavior.

## Validation

- 9 focused regression tests pass.
- Python compilation passes.
- Wheel and source distribution build successfully.
- Tested `unsloth/Qwen3-8B-unsloth-bnb-4bit` on CPU and ROCm.
- Tested Qwen3.8-27B NF4 on a 4 GB Radeon RX 6400:
  - Correctly generated `Blue`.
  - Peak accelerator memory: 2,540.7 MiB.
  - Peak process RSS with prefetch: 4,314.4 MiB.
  - Effective rate: 0.0578 generated tokens/s.
  - Prefetch reduced the measured two-token generation time from 42.9 s to 34.6 s.

## Notes

- No model weights or generated layer shards are included.
- Resident multimodal modules remain enabled by default.
- `--text-only` disables image and video inputs for that model instance.
- This does not add GGUF support.
- Hardware-specific setup and benchmark details are documented in
  `ROCM_RX6400.md`.