### PR TITLE
feat: Add fixed-slot GPU expert streaming for PhiMoE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ airllm.egg-info
 build
 dist
 __pycache__
+.venv-rocm/
+models/
+.pytest_cache/
 # Package README is generated from the top-level README.md at build time
 air_llm/README.md

--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -33,6 +33,7 @@ else:
         ("AirLLMMixtral", ".airllm_mixtral"),
         ("AirLLMKimiK3", ".airllm_kimi_k3"),
         ("AirLLMQwen3_5", ".airllm_qwen3_5"),
+        ("AirLLMPhiMoE", ".airllm_phimoe"),
     ):
         try:
             _mod = __import__(__name__ + _module, fromlist=[_name])
@@ -42,4 +43,3 @@ else:
                 f"airllm: optional model class {_name} is unavailable ({_e}). "
                 f"This only affects that specific model family; the generic streaming path still works."
             )
-

--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -3,10 +3,12 @@ from typing import List, Optional, Tuple, Union
 from tqdm import tqdm
 from pathlib import Path
 import time
+import math
 from concurrent.futures import ThreadPoolExecutor
 
 import torch
 import transformers
+from safetensors import safe_open
 from transformers import AutoConfig, AutoTokenizer, GenerationConfig
 from transformers.generation import GenerationMixin
 from accelerate import init_empty_weights
@@ -14,6 +16,7 @@ from accelerate.utils.modeling import set_module_tensor_to_device
 from transformers.quantizers import AutoHfQuantizer
 
 from .profiler import LayeredProfiler
+from .expert_slot_cache import ExpertHostBank, ExpertSlotRuntime
 
 from .utils import clean_memory, load_layer, layer_tensor_names, load_layer_subset, \
     find_or_create_local_splitted_path
@@ -82,7 +85,8 @@ class AirLLMBaseModel:
 
     def __init__(self, model_local_path_or_repo_id, device="cuda:0", dtype=None, max_seq_len=512,
                  layer_shards_saving_path=None, profiling_mode=False, compression=None,
-                 hf_token=None, prefetching=True, delete_original=False):
+                 hf_token=None, prefetching=True, delete_original=False,
+                 expert_cache_gb=0.0, expert_cache_backend="none"):
         """
         Parameters
         ----------
@@ -108,6 +112,12 @@ class AirLLMBaseModel:
             overlap the next layer's disk load with the current layer's compute
         delete_original: bool, optional
             delete the original downloaded checkpoint after splitting to save disk space
+        expert_cache_gb: float, optional
+            GPU-memory budget, in GiB, for fixed PhiMoE expert slots.
+        expert_cache_backend: str, optional
+            ``"slot"`` explicitly selects the PhiMoE fixed-slot runtime with resident dense
+            weights and an eager host expert bank. The default ``"none"`` preserves AirLLM's
+            existing immediate expert eviction.
         """
 
         self.profiling_mode = profiling_mode
@@ -125,9 +135,43 @@ class AirLLMBaseModel:
         self.compression = compression
         self.hf_token = hf_token
 
+        try:
+            self.expert_cache_gb = float(expert_cache_gb)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("expert_cache_gb must be a finite non-negative number") from exc
+        if not math.isfinite(self.expert_cache_gb) or self.expert_cache_gb < 0:
+            raise ValueError("expert_cache_gb must be a finite non-negative number")
+        self.expert_cache_capacity_bytes = int(self.expert_cache_gb * 1024 ** 3)
+        self.expert_cache_backend = (
+            "none" if expert_cache_backend is None else str(expert_cache_backend).lower()
+        )
+        if self.expert_cache_backend not in ("none", "slot"):
+            raise ValueError("expert_cache_backend must be 'none' or 'slot'")
+        if self.expert_cache_backend == "none" and self.expert_cache_capacity_bytes:
+            raise ValueError("expert_cache_gb requires expert_cache_backend='slot'")
+        if self.expert_cache_backend == "slot":
+            if not self.expert_cache_capacity_bytes:
+                raise ValueError("expert_cache_backend='slot' requires expert_cache_gb > 0")
+            if compression is not None:
+                raise ValueError("expert_cache_backend='slot' does not support compressed shards")
+
         restore_relocated_transformers_symbols()
 
         self.set_layer_names_dict()
+
+        self.running_device = device
+        self.device = torch.device(self.running_device)
+        if self.expert_cache_backend == "slot":
+            if self.device.type != "cuda" or not torch.cuda.is_available():
+                raise ValueError("expert_cache_gb requires a CUDA-compatible device (CUDA or ROCm)")
+            if not self.layer_names_dict.get("expert_prefix"):
+                raise ValueError(
+                    "expert_cache_gb requires a model adapter with per-expert streaming support"
+                )
+        if self.expert_cache_backend == "slot" and not self.supports_expert_slot_backend():
+            raise ValueError(
+                "expert_cache_backend='slot' is currently supported only by the PhiMoE adapter"
+            )
 
         self.model_local_path, self.checkpoint_path = find_or_create_local_splitted_path(
             model_local_path_or_repo_id,
@@ -136,9 +180,6 @@ class AirLLMBaseModel:
             layer_names=self.layer_names_dict,
             hf_token=hf_token,
             delete_original=delete_original)
-
-        self.running_device = device
-        self.device = torch.device(self.running_device)
 
         # Prefer transformers' native implementation; only trust the model's bundled remote code when
         # transformers doesn't recognize the architecture. Vendored remote code is frequently pinned
@@ -175,6 +216,10 @@ class AirLLMBaseModel:
 
         # prefetch executor / state
         self.prefetching = prefetching
+        if self.expert_cache_backend == "slot" and self.prefetching:
+            print("layer prefetching is unnecessary with resident slot-backend dense weights; "
+                  "disabling the ordinary layer prefetcher.")
+            self.prefetching = False
         if self.compression is not None and self.prefetching:
             print("prefetching is not supported together with compression for now; disabling prefetching.")
             self.prefetching = False
@@ -198,9 +243,17 @@ class AirLLMBaseModel:
 
         self.set_layers_from_layer_names()
         self._load_resident_modules()
+        self._expert_slot_runtime = None
         self._install_streaming_hooks()
+        if self.expert_cache_backend == "slot" and not self._expert_streaming:
+            raise ValueError(
+                "expert_cache_gb was requested, but no per-expert safetensor modules were found"
+            )
 
     # ---- customization hooks for subclasses -------------------------------------------------
+
+    def supports_expert_slot_backend(self):
+        return False
 
     def get_generation_config(self):
         try:
@@ -685,7 +738,11 @@ class AirLLMBaseModel:
 
         self._streamed_set = set(self._streamed_indices)
 
-        self._setup_expert_streaming()
+        self._setup_expert_streaming(install_hooks=self.expert_cache_backend == "none")
+
+        if self.expert_cache_backend == "slot":
+            self._initialize_expert_slot_runtime()
+            return
 
         for idx in self._streamed_indices:
             module = self.layers[idx]
@@ -695,7 +752,7 @@ class AirLLMBaseModel:
 
     # ---- per-expert streaming ---------------------------------------------------------------
 
-    def _setup_expert_streaming(self):
+    def _setup_expert_streaming(self, *, install_hooks=True):
         """Stream individual MoE experts instead of whole decoder layers, where that is possible.
 
         A sparse MoE layer holds hundreds of experts but routes each token to a handful of them.
@@ -710,6 +767,7 @@ class AirLLMBaseModel:
         self._expert_streaming = False
         self._expert_keys = {}
         self._non_expert_keys = {}
+        self._expert_param_prefixes = {}
 
         expert_prefix = self.layer_names_dict.get('expert_prefix')
         if not expert_prefix:
@@ -763,15 +821,134 @@ class AirLLMBaseModel:
                     continue
                 expert_module = experts_container[expert_idx]
                 expert_module._airllm_expert = (idx, expert_idx)
-                expert_module.register_forward_pre_hook(self._expert_pre_hook)
-                expert_module.register_forward_hook(self._expert_post_hook)
+                first_key = keys[0]
+                marker_pos = first_key.find(marker)
+                self._expert_param_prefixes[(idx, expert_idx)] = (
+                    first_key[:marker_pos + len(marker)] + str(expert_idx)
+                )
+                if install_hooks:
+                    expert_module.register_forward_pre_hook(self._expert_pre_hook)
+                    expert_module.register_forward_hook(self._expert_post_hook)
                 hooked += 1
 
         if hooked:
             self._expert_streaming = True
             n_layers = len(self._expert_keys)
-            print(f"per-expert streaming enabled: {hooked} experts across {n_layers} layers "
-                  f"load on demand, so only the experts a token routes to are materialised.")
+            if install_hooks:
+                print(f"per-expert streaming enabled: {hooked} experts across {n_layers} layers "
+                      f"load on demand, so only the experts a token routes to are materialised.")
+
+    def _slot_dense_keysets(self):
+        """Return the non-expert checkpoint keys that become permanently GPU resident."""
+        keysets = {}
+        for idx in self._streamed_indices:
+            keys = self._non_expert_keys.get(idx)
+            if keys is None:
+                keys = layer_tensor_names(self.checkpoint_path, self.layer_names[idx])
+            keysets[idx] = keys
+        return keysets
+
+    def _estimate_slot_dense_bytes(self, keysets):
+        """Estimate dense residency at the running dtype without reading tensor payloads."""
+        dtype_bytes = torch.empty((), dtype=self.running_dtype).element_size()
+        total = 0
+        for idx, keys in keysets.items():
+            shard = Path(self.checkpoint_path) / f"{self.layer_names[idx]}.safetensors"
+            with safe_open(str(shard), framework="pt") as handle:
+                for key in keys:
+                    tensor_slice = handle.get_slice(key)
+                    source_dtype = tensor_slice.get_dtype()
+                    if source_dtype not in ("F16", "BF16"):
+                        raise ValueError(
+                            "slot backend requires uncompressed FP16/BF16 dense weights; "
+                            f"{key} is {source_dtype}"
+                        )
+                    total += math.prod(tensor_slice.get_shape()) * dtype_bytes
+        return total
+
+    def _load_slot_dense_weights(self, keysets):
+        moved = []
+        for idx in self._streamed_indices:
+            state_dict = load_layer_subset(
+                self.checkpoint_path,
+                self.layer_names[idx],
+                keysets[idx],
+            )
+            moved.extend(self.move_layer_to_device(state_dict))
+            del state_dict
+        return moved
+
+    def _initialize_expert_slot_runtime(self):
+        """Build the explicit PhiMoE host-bank/fixed-slot execution path."""
+        if not self._expert_streaming:
+            raise ValueError("slot backend found no per-expert safetensor layout")
+        if self.hf_quantizer is not None:
+            raise ValueError("slot backend does not yet support pre-quantized checkpoints")
+        if self.running_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("slot backend supports only float16 or bfloat16 runtime dtype")
+
+        host_bank = ExpertHostBank(
+            self.checkpoint_path,
+            self.layer_names,
+            self._expert_keys,
+            self._expert_param_prefixes,
+            self.running_dtype,
+        )
+        keysets = self._slot_dense_keysets()
+        dense_bytes = self._estimate_slot_dense_bytes(keysets)
+        slot_count = self.expert_cache_capacity_bytes // host_bank.expert_bytes
+        if slot_count < 1:
+            raise ValueError(
+                f"expert_cache_gb is smaller than one {host_bank.expert_bytes / 1024 ** 2:.2f} MiB expert"
+            )
+
+        free_bytes, total_bytes = torch.cuda.mem_get_info(self.device)
+        cache_bytes = slot_count * host_bank.expert_bytes
+        scratch_bytes = ExpertSlotRuntime.scratch_slots * host_bank.expert_bytes
+        headroom = max(512 * 1024 ** 2, total_bytes // 10)
+        required = dense_bytes + cache_bytes + scratch_bytes + headroom
+        if required > free_bytes:
+            raise RuntimeError(
+                "insufficient accelerator memory for PhiMoE slot backend: "
+                f"dense={dense_bytes / 1024 ** 2:.1f} MiB, "
+                f"cache={cache_bytes / 1024 ** 2:.1f} MiB, "
+                f"scratch={scratch_bytes / 1024 ** 2:.1f} MiB, "
+                f"required headroom={headroom / 1024 ** 2:.1f} MiB, "
+                f"free={free_bytes / 1024 ** 2:.1f} MiB; lower expert_cache_gb"
+            )
+
+        runtime = None
+        moved = []
+        dense_param_names = [name for keys in keysets.values() for name in keys]
+        try:
+            runtime = ExpertSlotRuntime(host_bank, self.expert_cache_capacity_bytes, self.device)
+            moved = self._load_slot_dense_weights(keysets)
+            runtime.dense_resident_bytes = self._device_storage_bytes(moved) or dense_bytes
+
+            expert_prefix = self.layer_names_dict['expert_prefix']
+            for idx in self._expert_keys:
+                container = self.layers[idx]
+                for attr in expert_prefix.split('.'):
+                    container = getattr(container, attr)
+                container._airllm_slot_runtime = runtime
+                container._airllm_layer_idx = idx
+            self._expert_slot_runtime = runtime
+        except Exception as exc:
+            # ``move_layer_to_device`` can fail partway through a layer before returning its list
+            # of moved names. Inspect every planned dense name so setup remains atomic in that
+            # case too.
+            self._evict_param_names(dense_param_names)
+            if runtime is not None:
+                runtime.close()
+            clean_memory()
+            raise RuntimeError("failed to initialize PhiMoE slot backend") from exc
+
+        print(
+            "PhiMoE slot backend enabled: "
+            f"{host_bank.expert_count} experts / {host_bank.nbytes / 1024 ** 3:.2f} GiB host bank, "
+            f"{runtime.slot_count} fixed GPU cache slots, "
+            f"{runtime.dense_resident_bytes / 1024 ** 3:.2f} GiB dense weights resident."
+        )
 
     def _expert_pre_hook(self, module, args):
         layer_idx, expert_idx = module._airllm_expert
@@ -784,6 +961,72 @@ class AirLLMBaseModel:
             set_module_tensor_to_device(self.model, param_name, 'meta')
         module._airllm_moved = []
         return output
+
+    # ---- fixed-slot lifecycle ---------------------------------------------------------------
+
+    def _resolve_model_tensor(self, param_name):
+        module_path, _, attr = param_name.rpartition('.')
+        try:
+            module = self.model.get_submodule(module_path) if module_path else self.model
+        except AttributeError:
+            return None
+        tensor = module._parameters.get(attr)
+        if tensor is None:
+            tensor = module._buffers.get(attr)
+        return tensor
+
+    def _device_storage_bytes(self, param_names):
+        """Count unique accelerator storages owned by ``param_names``."""
+        storages = {}
+        for param_name in param_names:
+            tensor = self._resolve_model_tensor(param_name)
+            if tensor is None or tensor.device.type == 'meta':
+                continue
+            try:
+                storage = tensor.untyped_storage()
+                storage_key = (tensor.device.type, tensor.device.index, storage.data_ptr())
+                storages[storage_key] = storage.nbytes()
+            except (AttributeError, RuntimeError):
+                # Tensor subclasses may not expose untyped_storage; their logical payload is the
+                # best portable fallback and remains conservative for ordinary parameters.
+                storage_key = (param_name,)
+                storages[storage_key] = tensor.numel() * tensor.element_size()
+        return sum(storages.values())
+
+    def _evict_param_names(self, param_names):
+        for param_name in param_names:
+            tensor = self._resolve_model_tensor(param_name)
+            if tensor is not None and tensor.device.type != 'meta':
+                set_module_tensor_to_device(self.model, param_name, 'meta')
+
+    def get_expert_cache_stats(self):
+        """Return fixed-slot statistics, or a disabled snapshot for normal streaming."""
+        slot_runtime = getattr(self, '_expert_slot_runtime', None)
+        if slot_runtime is not None:
+            return dict(slot_runtime.stats())
+        return {
+            "enabled": False,
+            "backend": "none",
+            "capacity_bytes": 0,
+            "resident_bytes": 0,
+            "resident_experts": 0,
+        }
+
+    def reset_expert_cache_stats(self):
+        """Reset hit/miss counters without changing expert residency."""
+        slot_runtime = getattr(self, '_expert_slot_runtime', None)
+        if slot_runtime is not None:
+            slot_runtime.reset_stats()
+
+    def clear_expert_cache(self):
+        """Synchronize outstanding work and clear logical expert residency."""
+        slot_runtime = getattr(self, '_expert_slot_runtime', None)
+        if slot_runtime is not None:
+            slot_runtime.clear()
+            return
+        if self.device.type == 'cuda' and torch.cuda.is_available():
+            torch.cuda.synchronize(self.device)
+        clean_memory()
 
     def _next_streamed_idx(self, idx):
         nxt = idx + 1

--- a/air_llm/airllm/airllm_phimoe.py
+++ b/air_llm/airllm/airllm_phimoe.py
@@ -1,0 +1,163 @@
+"""PhiMoE adapter exposing checkpoint experts as independently streamable modules."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from transformers.activations import ACT2FN
+
+from .airllm_base import AirLLMBaseModel
+
+
+class PhiMoEStreamedExpert(nn.Module):
+    """Checkpoint-compatible PhiMoE gated MLP allocated entirely on ``meta``."""
+
+    def __init__(self, config):
+        super().__init__()
+        hidden = config.hidden_size
+        intermediate = config.intermediate_size
+        self.w1 = nn.Linear(hidden, intermediate, bias=False, device='meta')
+        self.w2 = nn.Linear(intermediate, hidden, bias=False, device='meta')
+        self.w3 = nn.Linear(hidden, intermediate, bias=False, device='meta')
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states):
+        return self.w2(self.act_fn(self.w1(hidden_states)) * self.w3(hidden_states))
+
+
+class PhiMoEStreamedExperts(nn.Module):
+    """Indexed expert collection with Transformers' packed-bank calling convention.
+
+    Numeric child names intentionally produce state-dict paths such as
+    ``block_sparse_moe.experts.3.w1.weight``, matching the published checkpoint and AirLLM's
+    existing per-expert discovery logic.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_local_experts
+        self._airllm_slot_runtime = None
+        self._airllm_layer_idx = None
+        for expert_idx in range(self.num_experts):
+            self.add_module(str(expert_idx), PhiMoEStreamedExpert(config))
+
+    def __len__(self):
+        return self.num_experts
+
+    def __getitem__(self, expert_idx):
+        return self._modules[str(int(expert_idx))]
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final_hidden_states = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = torch.nn.functional.one_hot(
+                top_k_index, num_classes=self.num_experts
+            ).permute(2, 1, 0)
+            # One device-to-host synchronization per MoE layer is required because Python module
+            # hooks decide which individual expert weights to materialize.
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero().flatten().tolist()
+
+        if self._airllm_slot_runtime is None:
+            for expert_idx in expert_hit:
+                top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+                current_state = hidden_states[token_idx]
+                current_hidden_states = self[expert_idx](current_state)
+                current_hidden_states = current_hidden_states * top_k_weights[
+                    token_idx, top_k_pos, None
+                ]
+                final_hidden_states.index_add_(
+                    0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
+                )
+            return final_hidden_states
+
+        # The native PhiMoE implementation flattens batch and sequence before expert dispatch.
+        # The validation workload is batch one, so one flattened token is decode; larger routed
+        # sets are prefill and use transient scratch slots to avoid polluting the global cache.
+        admit = hidden_states.ndim == 2 and hidden_states.shape[0] == 1
+
+        def execute_one(expert_idx, weights):
+            w1, w2, w3 = weights
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            current_hidden_states = F.linear(current_state, w1)
+            current_hidden_states = self[expert_idx].act_fn(current_hidden_states)
+            current_hidden_states = current_hidden_states * F.linear(current_state, w3)
+            current_hidden_states = F.linear(current_hidden_states, w2)
+            current_hidden_states = current_hidden_states * top_k_weights[
+                token_idx, top_k_pos, None
+            ]
+            final_hidden_states.index_add_(
+                0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
+            )
+
+        self._airllm_slot_runtime.execute(
+            self._airllm_layer_idx,
+            expert_hit,
+            admit=admit,
+            callback=execute_one,
+        )
+        return final_hidden_states
+
+
+class AirLLMPhiMoE(AirLLMBaseModel):
+    """AirLLM adapter for ``PhiMoEForCausalLM`` checkpoints.
+
+    Current Transformers packs every layer's experts into two bank parameters. AirLLM instead
+    needs the checkpoint's original per-expert module layout so each routed expert can be loaded
+    independently. Attention, routing, KV caching, and generation remain owned by Transformers.
+    """
+
+    def set_layer_names_dict(self):
+        self.layer_names_dict = {
+            'embed': 'model.embed_tokens',
+            'layer_prefix': 'model.layers',
+            'norm': 'model.norm',
+            'lm_head': 'lm_head',
+            'expert_prefix': 'block_sparse_moe.experts',
+        }
+
+    def supports_expert_slot_backend(self):
+        return True
+
+    def init_model(self):
+        super().init_model()
+        # The replacement below owns expert dispatch, so Transformers must not swap its packed
+        # expert bank between grouped_mm and batched_mm around decoding. Besides being inapplicable
+        # to independently hooked modules, that automatic restore rejects AirLLM's runtime class.
+        self.config._experts_implementation = 'eager'
+        layers = self.model.model.layers
+        for layer in layers:
+            # Transformers 5 renamed the checkpoint's ``block_sparse_moe`` module to ``mlp`` and
+            # its ``gate`` child to ``router``.  AirLLM deliberately streams the original shard
+            # keys, so retain aliases for those published names while the native forward keeps
+            # calling ``layer.mlp``.  Older Transformers releases already expose the old names.
+            sparse_moe = getattr(layer, 'block_sparse_moe', None)
+            if sparse_moe is None:
+                sparse_moe = getattr(layer, 'mlp', None)
+                if sparse_moe is None:
+                    raise RuntimeError(
+                        f"Unsupported PhiMoE decoder layout: {type(layer).__name__}"
+                    )
+                layer.block_sparse_moe = sparse_moe
+            if not hasattr(sparse_moe, 'gate') and hasattr(sparse_moe, 'router'):
+                sparse_moe.gate = sparse_moe.router
+
+            packed = sparse_moe.experts
+            if self._is_checkpoint_indexed(packed):
+                continue
+            if not (hasattr(packed, 'gate_up_proj') and hasattr(packed, 'down_proj')):
+                raise RuntimeError(
+                    f"Unsupported PhiMoE expert representation: {type(packed).__name__}"
+                )
+            replacement = PhiMoEStreamedExperts(self.config)
+            replacement.train(packed.training)
+            sparse_moe.experts = replacement
+
+    @staticmethod
+    def _is_checkpoint_indexed(experts):
+        try:
+            first = experts[0]
+        except (KeyError, TypeError, IndexError):
+            return False
+        return all(hasattr(first, name) for name in ('w1', 'w2', 'w3'))

--- a/air_llm/airllm/auto_model.py
+++ b/air_llm/airllm/auto_model.py
@@ -23,6 +23,7 @@ ARCH_OVERRIDES = {
     "InternLMForCausalLM": "AirLLMInternLM",
     "KimiK3ForConditionalGeneration": "AirLLMKimiK3",
     "Qwen3_5ForConditionalGeneration": "AirLLMQwen3_5",
+    "PhiMoEForCausalLM": "AirLLMPhiMoE",
 }
 
 

--- a/air_llm/airllm/expert_slot_cache.py
+++ b/air_llm/airllm/expert_slot_cache.py
@@ -1,0 +1,553 @@
+"""Fixed-slot expert runtime for memory-constrained MoE inference.
+
+The compatibility expert cache keeps weights attached to individual ``nn.Module`` objects.  That
+is portable, but a miss allocates new accelerator tensors and eviction replaces them with ``meta``
+parameters.  This module provides the lower-overhead alternative used by the explicit PhiMoE slot
+backend: one normalized CPU bank, fixed accelerator storage, and a two-lane pinned transfer pipe.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+import math
+import time
+from typing import Callable, Iterable
+
+import torch
+from safetensors import safe_open
+
+
+ExpertKey = tuple[int, int]
+
+_ALLOWED_SOURCE_DTYPES = {"F16", "BF16"}
+_PROJECTIONS = ("w1.weight", "w2.weight", "w3.weight")
+
+
+def _numel(shape: Iterable[int]) -> int:
+    return math.prod(int(dim) for dim in shape)
+
+
+def _available_host_memory_bytes() -> int | None:
+    """Return Linux MemAvailable when present, otherwise leave allocation to PyTorch."""
+    try:
+        with open("/proc/meminfo", "r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+@dataclass(frozen=True)
+class SlotReservation:
+    slot: int
+    hit: bool
+    evicted_key: ExpertKey | None = None
+
+
+class FixedSlotLRU:
+    """Pure bookkeeping for a fixed number of equal-size expert slots."""
+
+    def __init__(self, slot_count: int):
+        if slot_count < 1:
+            raise ValueError("fixed expert cache requires at least one slot")
+        self.slot_count = int(slot_count)
+        self._entries: OrderedDict[ExpertKey, int] = OrderedDict()
+        self._free_slots = list(range(self.slot_count - 1, -1, -1))
+
+    def lookup(self, key: ExpertKey, *, touch: bool = True) -> int | None:
+        slot = self._entries.get(key)
+        if slot is not None and touch:
+            self._entries.move_to_end(key)
+        return slot
+
+    def reserve(
+        self,
+        key: ExpertKey,
+        *,
+        protected: Iterable[ExpertKey] = (),
+    ) -> SlotReservation | None:
+        existing = self.lookup(key)
+        if existing is not None:
+            return SlotReservation(existing, True)
+
+        if self._free_slots:
+            slot = self._free_slots.pop()
+            self._entries[key] = slot
+            return SlotReservation(slot, False)
+
+        protected_set = set(protected)
+        victim = next(
+            (candidate for candidate in self._entries if candidate not in protected_set),
+            None,
+        )
+        if victim is None:
+            return None
+        slot = self._entries.pop(victim)
+        self._entries[key] = slot
+        return SlotReservation(slot, False, victim)
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._free_slots = list(range(self.slot_count - 1, -1, -1))
+
+    @property
+    def resident_count(self) -> int:
+        return len(self._entries)
+
+    def keys(self) -> tuple[ExpertKey, ...]:
+        return tuple(self._entries)
+
+
+class ExpertHostBank:
+    """Three contiguous pageable CPU banks indexed by ``(layer, expert)``."""
+
+    host_reserve_bytes = 2 * 1024 ** 3
+    host_preflight_min_bank_bytes = 512 * 1024 ** 2
+
+    def __init__(
+        self,
+        checkpoint_path,
+        layer_names,
+        expert_keys,
+        expert_param_prefixes,
+        dtype: torch.dtype,
+    ):
+        if dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("slot expert bank supports only float16 or bfloat16 runtime dtype")
+
+        self.dtype = dtype
+        self.projection_names = _PROJECTIONS
+        self._flat_index: dict[ExpertKey, int] = {}
+        self._entries = [
+            (layer_idx, expert_idx)
+            for layer_idx in sorted(expert_keys)
+            for expert_idx in sorted(expert_keys[layer_idx])
+        ]
+        if not self._entries:
+            raise ValueError("slot expert bank found no checkpoint-indexed experts")
+        self._flat_index = {key: flat for flat, key in enumerate(self._entries)}
+
+        checkpoint_path = Path(checkpoint_path)
+        metadata: dict[str, tuple[int, ...]] = {}
+        source_dtypes: set[str] = set()
+        layer_records: dict[int, list[tuple[int, dict[str, str]]]] = {}
+
+        for layer_idx, expert_idx in self._entries:
+            prefix = expert_param_prefixes[(layer_idx, expert_idx)]
+            by_projection = {}
+            for tensor_name in expert_keys[layer_idx][expert_idx]:
+                expected_prefix = prefix + "."
+                if not tensor_name.startswith(expected_prefix):
+                    raise ValueError(f"expert tensor {tensor_name!r} is outside {prefix!r}")
+                by_projection[tensor_name[len(expected_prefix):]] = tensor_name
+            if set(by_projection) != set(_PROJECTIONS):
+                raise ValueError(
+                    f"PhiMoE expert {layer_idx, expert_idx} must contain exactly "
+                    f"{', '.join(_PROJECTIONS)}; found {sorted(by_projection)}"
+                )
+            layer_records.setdefault(layer_idx, []).append((expert_idx, by_projection))
+
+        # Validate every tensor before committing several GiB of host memory.
+        for layer_idx, records in layer_records.items():
+            shard = checkpoint_path / f"{layer_names[layer_idx]}.safetensors"
+            with safe_open(str(shard), framework="pt") as handle:
+                available = set(handle.keys())
+                for expert_idx, projections in records:
+                    for projection, tensor_name in projections.items():
+                        if tensor_name not in available:
+                            raise ValueError(
+                                f"missing expert tensor {tensor_name!r} in {shard.name}"
+                            )
+                        tensor_slice = handle.get_slice(tensor_name)
+                        shape = tuple(tensor_slice.get_shape())
+                        source_dtype = tensor_slice.get_dtype()
+                        if source_dtype not in _ALLOWED_SOURCE_DTYPES:
+                            raise ValueError(
+                                "slot backend requires FP16/BF16 experts; "
+                                f"{tensor_name} is {source_dtype}"
+                            )
+                        source_dtypes.add(source_dtype)
+                        expected = metadata.setdefault(projection, shape)
+                        if shape != expected:
+                            raise ValueError(
+                                f"non-uniform {projection} shape for expert "
+                                f"{layer_idx, expert_idx}: "
+                                f"expected {expected}, found {shape}"
+                            )
+
+        dtype_bytes = torch.empty((), dtype=dtype).element_size()
+        self.expert_bytes = sum(_numel(metadata[name]) * dtype_bytes for name in _PROJECTIONS)
+        self.nbytes = self.expert_bytes * len(self._entries)
+        available_host = _available_host_memory_bytes()
+        if (
+            self.nbytes >= self.host_preflight_min_bank_bytes
+            and available_host is not None
+            and available_host < self.nbytes + self.host_reserve_bytes
+        ):
+            raise MemoryError(
+                "insufficient host memory for slot expert bank: "
+                f"need {self.nbytes / 1024 ** 3:.2f} GiB plus 2 GiB reserve, "
+                f"have {available_host / 1024 ** 3:.2f} GiB available"
+            )
+
+        started = time.perf_counter()
+        try:
+            self.banks = {
+                name: torch.empty((len(self._entries), *metadata[name]), dtype=dtype)
+                for name in _PROJECTIONS
+            }
+            source_tensor_reads = 0
+            with torch.no_grad():
+                for layer_idx, records in layer_records.items():
+                    shard = checkpoint_path / f"{layer_names[layer_idx]}.safetensors"
+                    with safe_open(str(shard), framework="pt") as handle:
+                        for expert_idx, projections in records:
+                            flat = self._flat_index[(layer_idx, expert_idx)]
+                            for projection in _PROJECTIONS:
+                                self.banks[projection][flat].copy_(
+                                    handle.get_tensor(projections[projection])
+                                )
+                                source_tensor_reads += 1
+        except Exception as exc:
+            self.banks = {}
+            raise RuntimeError("failed to build the pageable PhiMoE expert bank") from exc
+
+        self.source_dtypes = tuple(sorted(source_dtypes))
+        self.source_tensor_reads = source_tensor_reads
+        self.load_seconds = time.perf_counter() - started
+
+    def tensors(self, key: ExpertKey) -> tuple[torch.Tensor, ...]:
+        try:
+            flat = self._flat_index[key]
+        except KeyError as exc:
+            raise KeyError(f"unknown expert {key}") from exc
+        return tuple(self.banks[name][flat] for name in _PROJECTIONS)
+
+    @property
+    def expert_count(self) -> int:
+        return len(self._entries)
+
+
+@dataclass
+class _ExpertRequest:
+    key: ExpertKey
+    expert_idx: int
+    kind: str
+    index: int
+    hit: bool
+    lane: int | None = None
+    ready_event: object | None = None
+
+
+class ExpertSlotRuntime:
+    """Fixed GPU expert slots with a pageable-bank -> pinned-stage -> GPU pipeline."""
+
+    scratch_slots = 2
+
+    def __init__(
+        self,
+        host_bank: ExpertHostBank,
+        capacity_bytes: int,
+        device: torch.device,
+    ):
+        self.host_bank = host_bank
+        self.capacity_bytes = int(capacity_bytes)
+        self.device = torch.device(device)
+        if self.device.type != "cuda" or not torch.cuda.is_available():
+            raise ValueError("slot expert runtime requires a CUDA-compatible device (CUDA or ROCm)")
+
+        self.expert_bytes = host_bank.expert_bytes
+        self.slot_count = self.capacity_bytes // self.expert_bytes
+        if self.slot_count < 1:
+            expert_mib = self.expert_bytes / 1024 ** 2
+            raise ValueError(f"expert_cache_gb is smaller than one {expert_mib:.2f} MiB expert")
+
+        self.lru = FixedSlotLRU(self.slot_count)
+        self.transfer_stream = torch.cuda.Stream(device=self.device)
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="airllm-expert-stage")
+        self._in_execute = False
+        self.dense_resident_bytes = 0
+
+        try:
+            self.cache_banks = {
+                name: torch.empty((self.slot_count, *bank.shape[1:]), dtype=bank.dtype,
+                                  device=self.device)
+                for name, bank in host_bank.banks.items()
+            }
+            self.scratch_banks = {
+                name: torch.empty((self.scratch_slots, *bank.shape[1:]), dtype=bank.dtype,
+                                  device=self.device)
+                for name, bank in host_bank.banks.items()
+            }
+            self.staging_banks = {
+                name: torch.empty((self.scratch_slots, *bank.shape[1:]), dtype=bank.dtype,
+                                  device="cpu", pin_memory=True)
+                for name, bank in host_bank.banks.items()
+            }
+        except Exception:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self.cache_banks = {}
+            self.scratch_banks = {}
+            self.staging_banks = {}
+            raise
+
+        self._cache_ready = [None] * self.slot_count
+        self._cache_last_use = [None] * self.slot_count
+        self._scratch_ready = [None] * self.scratch_slots
+        self._scratch_last_use = [None] * self.scratch_slots
+        self._lane_transfer_done = [None] * self.scratch_slots
+        self.reset_stats()
+
+    @property
+    def allocated_cache_bytes(self) -> int:
+        return self.slot_count * self.expert_bytes
+
+    @property
+    def scratch_bytes(self) -> int:
+        return self.scratch_slots * self.expert_bytes
+
+    @property
+    def pinned_staging_bytes(self) -> int:
+        return self.scratch_slots * self.expert_bytes
+
+    @property
+    def allocated_device_bytes(self) -> int:
+        return self.allocated_cache_bytes + self.scratch_bytes + self.dense_resident_bytes
+
+    def _destination_banks(self, request: _ExpertRequest) -> tuple[torch.Tensor, ...]:
+        banks = self.cache_banks if request.kind == "cache" else self.scratch_banks
+        return tuple(banks[name][request.index] for name in self.host_bank.projection_names)
+
+    def _destination_last_use(self, request: _ExpertRequest):
+        events = self._cache_last_use if request.kind == "cache" else self._scratch_last_use
+        return events[request.index]
+
+    def _set_destination_ready(self, request: _ExpertRequest, event) -> None:
+        events = self._cache_ready if request.kind == "cache" else self._scratch_ready
+        events[request.index] = event
+
+    def _destination_ready(self, request: _ExpertRequest):
+        events = self._cache_ready if request.kind == "cache" else self._scratch_ready
+        return events[request.index]
+
+    def _record_destination_use(self, request: _ExpertRequest, stream) -> None:
+        event = torch.cuda.Event(blocking=False)
+        event.record(stream)
+        events = self._cache_last_use if request.kind == "cache" else self._scratch_last_use
+        events[request.index] = event
+
+    def _fill_staging_lane(self, lane: int, key: ExpertKey, previous_transfer) -> None:
+        if previous_transfer is not None:
+            previous_transfer.synchronize()
+        started = time.perf_counter()
+        with torch.no_grad():
+            for projection, source in zip(self.host_bank.projection_names,
+                                          self.host_bank.tensors(key)):
+                self.staging_banks[projection][lane].copy_(source)
+        self.host_stage_seconds += time.perf_counter() - started
+        self.host_stage_copies += 1
+
+    def _submit_stage(self, lane: int, request: _ExpertRequest) -> Future:
+        return self._executor.submit(
+            self._fill_staging_lane,
+            lane,
+            request.key,
+            self._lane_transfer_done[lane],
+        )
+
+    def _enqueue_transfer(self, lane: int, request: _ExpertRequest) -> None:
+        with torch.cuda.stream(self.transfer_stream):
+            last_use = self._destination_last_use(request)
+            if last_use is not None:
+                self.transfer_stream.wait_event(last_use)
+            for projection, destination in zip(
+                self.host_bank.projection_names,
+                self._destination_banks(request),
+            ):
+                destination.copy_(self.staging_banks[projection][lane], non_blocking=True)
+            ready = torch.cuda.Event(blocking=False)
+            ready.record(self.transfer_stream)
+        request.ready_event = ready
+        self._set_destination_ready(request, ready)
+        self._lane_transfer_done[lane] = ready
+        self.h2d_copies += 1
+        self.h2d_bytes += self.expert_bytes
+
+    def _plan(self, layer_idx: int, expert_indices: Iterable[int], admit: bool):
+        expert_indices = [int(index) for index in expert_indices]
+        protected = {(layer_idx, index) for index in expert_indices}
+        requests = []
+        miss_count = 0
+        for expert_idx in expert_indices:
+            key = (layer_idx, expert_idx)
+            existing = self.lru.lookup(key)
+            if existing is not None:
+                self.hits += 1
+                requests.append(_ExpertRequest(key, expert_idx, "cache", existing, True))
+                continue
+
+            self.misses += 1
+            reservation = self.lru.reserve(key, protected=protected) if admit else None
+            if reservation is not None:
+                if reservation.evicted_key is not None:
+                    self.evictions += 1
+                request = _ExpertRequest(key, expert_idx, "cache", reservation.slot, False)
+            else:
+                lane = miss_count % self.scratch_slots
+                request = _ExpertRequest(key, expert_idx, "scratch", lane, False)
+                if admit:
+                    self.bypasses += 1
+                else:
+                    self.prefill_skips += 1
+            request.lane = miss_count % self.scratch_slots
+            miss_count += 1
+            requests.append(request)
+        return requests
+
+    def execute(
+        self,
+        layer_idx: int,
+        expert_indices: Iterable[int],
+        *,
+        admit: bool,
+        callback: Callable[[int, tuple[torch.Tensor, ...]], None],
+    ) -> None:
+        """Execute callbacks in routing order while staging misses two experts ahead."""
+        if self._in_execute:
+            raise RuntimeError("slot expert runtime is not reentrant")
+        self._in_execute = True
+        pending: dict[int, Future | None] = {lane: None for lane in range(self.scratch_slots)}
+        lane_queues: dict[int, list[_ExpertRequest]] = {
+            lane: [] for lane in range(self.scratch_slots)
+        }
+        lane_positions = {lane: 0 for lane in range(self.scratch_slots)}
+
+        try:
+            requests = self._plan(layer_idx, expert_indices, admit)
+            for request in requests:
+                if not request.hit:
+                    lane_queues[request.lane].append(request)
+
+            # Stage and enqueue the first miss assigned to each lane.
+            for lane, queue in lane_queues.items():
+                if queue:
+                    pending[lane] = self._submit_stage(lane, queue[0])
+            for lane, queue in lane_queues.items():
+                if not queue:
+                    continue
+                pending[lane].result()
+                self._enqueue_transfer(lane, queue[0])
+                lane_positions[lane] = 1
+                pending[lane] = (
+                    self._submit_stage(lane, queue[1]) if len(queue) > 1 else None
+                )
+
+            compute_stream = torch.cuda.current_stream(self.device)
+            for request in requests:
+                ready = request.ready_event if not request.hit else self._destination_ready(request)
+                if ready is not None:
+                    compute_stream.wait_event(ready)
+                callback(request.expert_idx, self._destination_banks(request))
+                self._record_destination_use(request, compute_stream)
+
+                if request.hit:
+                    continue
+                lane = request.lane
+                queue = lane_queues[lane]
+                position = lane_positions[lane]
+                if position >= len(queue):
+                    pending[lane] = None
+                    continue
+
+                next_request = queue[position]
+                pending[lane].result()
+                self._enqueue_transfer(lane, next_request)
+                lane_positions[lane] = position + 1
+                following = position + 1
+                pending[lane] = (
+                    self._submit_stage(lane, queue[following])
+                    if following < len(queue)
+                    else None
+                )
+        except Exception:
+            # A caller may catch a failed generation and issue another request. Never leave a
+            # logical hit pointing at a partially copied slot in that case.
+            try:
+                torch.cuda.synchronize(self.device)
+            except Exception:
+                pass
+            self._invalidate()
+            raise
+        finally:
+            for future in pending.values():
+                if future is not None:
+                    # Any staging failure encountered on the normal path was already raised above.
+                    # If the callback failed first, do not replace that exception while draining
+                    # background work during cleanup.
+                    try:
+                        future.result()
+                    except Exception:
+                        pass
+            self._in_execute = False
+
+    def _invalidate(self) -> None:
+        self.lru.clear()
+        self._cache_ready = [None] * self.slot_count
+        self._cache_last_use = [None] * self.slot_count
+        self._scratch_ready = [None] * self.scratch_slots
+        self._scratch_last_use = [None] * self.scratch_slots
+        self._lane_transfer_done = [None] * self.scratch_slots
+
+    def clear(self) -> None:
+        torch.cuda.synchronize(self.device)
+        self._invalidate()
+
+    def reset_stats(self) -> None:
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+        self.bypasses = 0
+        self.prefill_skips = 0
+        self.h2d_copies = 0
+        self.h2d_bytes = 0
+        self.host_stage_copies = 0
+        self.host_stage_seconds = 0.0
+
+    def stats(self) -> dict[str, int | float | str | bool]:
+        return {
+            "enabled": True,
+            "backend": "slot",
+            "capacity_bytes": self.capacity_bytes,
+            "allocated_cache_bytes": self.allocated_cache_bytes,
+            "resident_bytes": self.lru.resident_count * self.expert_bytes,
+            "resident_experts": self.lru.resident_count,
+            "slot_count": self.slot_count,
+            "scratch_slots": self.scratch_slots,
+            "scratch_bytes": self.scratch_bytes,
+            "allocated_device_bytes": self.allocated_device_bytes,
+            "dense_resident_bytes": self.dense_resident_bytes,
+            "host_bank_bytes": self.host_bank.nbytes,
+            "host_bank_experts": self.host_bank.expert_count,
+            "host_bank_load_seconds": self.host_bank.load_seconds,
+            "host_bank_tensor_reads": self.host_bank.source_tensor_reads,
+            "pinned_staging_bytes": self.pinned_staging_bytes,
+            "generation_disk_expert_reads": 0,
+            "hits": self.hits,
+            "misses": self.misses,
+            "evictions": self.evictions,
+            "bypasses": self.bypasses,
+            "prefill_skips": self.prefill_skips,
+            "oom_retries": 0,
+            "h2d_copies": self.h2d_copies,
+            "h2d_bytes": self.h2d_bytes,
+            "host_stage_copies": self.host_stage_copies,
+            "host_stage_seconds": self.host_stage_seconds,
+        }
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=True, cancel_futures=True)

--- a/air_llm/examples/benchmark_expert_cache.py
+++ b/air_llm/examples/benchmark_expert_cache.py
@@ -1,0 +1,222 @@
+"""Benchmark AirLLM's fixed-slot PhiMoE runtime on a reproducible public model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import resource
+import statistics
+import time
+from pathlib import Path
+
+import torch
+from huggingface_hub import snapshot_download
+
+from airllm import AutoModel
+
+
+DEFAULT_MODEL = "microsoft/Phi-tiny-MoE-instruct"
+DEFAULT_REVISION = "2fe50e88d0e2a5a132563815686ea0dcc8e252b5"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--revision", default=DEFAULT_REVISION)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--dtype", choices=("float16", "bfloat16"), default="float16")
+    parser.add_argument("--expert-cache-gb", type=float, default=0.0)
+    parser.add_argument(
+        "--expert-cache-backend",
+        choices=("none", "slot"),
+        default="none",
+    )
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--max-new-tokens", type=int, default=8)
+    parser.add_argument("--max-seq-len", type=int, default=128)
+    parser.add_argument(
+        "--prompt",
+        default="Explain mixture-of-experts routing in one short sentence.",
+    )
+    parser.add_argument("--shard-dir", type=Path, default=Path("models/airllm-shards/phimoe"))
+    parser.add_argument("--hf-cache-dir", type=Path)
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        help="optional path for the machine-readable result (raw results should stay untracked)",
+    )
+    parser.add_argument("--no-prefetch", action="store_true")
+    parser.add_argument(
+        "--no-host-warmup",
+        action="store_true",
+        help="do not read split safetensors once before timing",
+    )
+    return parser.parse_args()
+
+
+def resolve_model_path(model, revision, cache_dir):
+    local = Path(model)
+    if local.exists():
+        return local.resolve()
+    kwargs = {"repo_id": model, "revision": revision}
+    if cache_dir is not None:
+        kwargs["cache_dir"] = str(cache_dir)
+    return Path(snapshot_download(**kwargs))
+
+
+def warm_host_pages(checkpoint_path):
+    """Populate the OS page cache so timed runs isolate GPU expert residency."""
+    total = 0
+    for shard in sorted(Path(checkpoint_path).glob("*.safetensors")):
+        with shard.open("rb", buffering=0) as handle:
+            while True:
+                chunk = handle.read(8 * 1024 ** 2)
+                if not chunk:
+                    break
+                total += len(chunk)
+    return total
+
+
+def sequences_from(output):
+    return output.sequences if hasattr(output, "sequences") else output
+
+
+def main():
+    args = parse_args()
+    if args.repetitions < 1:
+        raise ValueError("--repetitions must be at least one")
+    dtype = getattr(torch, args.dtype)
+    device = torch.device(args.device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires a CUDA-compatible PyTorch device (CUDA or ROCm)")
+
+    model_path = resolve_model_path(args.model, args.revision, args.hf_cache_dir)
+    args.shard_dir.mkdir(parents=True, exist_ok=True)
+    load_started = time.perf_counter()
+    model = AutoModel.from_pretrained(
+        str(model_path),
+        device=args.device,
+        dtype=dtype,
+        max_seq_len=args.max_seq_len,
+        layer_shards_saving_path=str(args.shard_dir),
+        prefetching=not args.no_prefetch,
+        expert_cache_gb=args.expert_cache_gb,
+        expert_cache_backend=args.expert_cache_backend,
+    )
+    load_seconds = time.perf_counter() - load_started
+
+    encoded = model.tokenizer(
+        args.prompt,
+        return_tensors="pt",
+        truncation=True,
+        max_length=args.max_seq_len,
+        padding=False,
+    )
+    input_ids = encoded["input_ids"].to(device)
+    attention_mask = encoded.get("attention_mask")
+    if attention_mask is not None:
+        attention_mask = attention_mask.to(device)
+
+    warmed_host_bytes = 0
+    if not args.no_host_warmup:
+        warmed_host_bytes = warm_host_pages(model.checkpoint_path)
+
+    # Compile/initialize the real kernels and generation path outside the timed repetitions.
+    model.generate(
+        input_ids,
+        attention_mask=attention_mask,
+        max_new_tokens=1,
+        min_new_tokens=1,
+        do_sample=False,
+        use_cache=True,
+    )
+    torch.cuda.synchronize(device)
+    model.clear_expert_cache()
+
+    repetitions = []
+    expected_ids = None
+    for repetition in range(args.repetitions):
+        model.clear_expert_cache()
+        model.reset_expert_cache_stats()
+        torch.cuda.reset_peak_memory_stats(device)
+        torch.cuda.synchronize(device)
+
+        started = time.perf_counter()
+        output = model.generate(
+            input_ids,
+            attention_mask=attention_mask,
+            max_new_tokens=args.max_new_tokens,
+            min_new_tokens=args.max_new_tokens,
+            do_sample=False,
+            use_cache=True,
+        )
+        torch.cuda.synchronize(device)
+        elapsed = time.perf_counter() - started
+
+        sequences = sequences_from(output)
+        generated = sequences[0, input_ids.shape[-1]:].detach().cpu().tolist()
+        if len(generated) != args.max_new_tokens:
+            raise RuntimeError(
+                f"expected exactly {args.max_new_tokens} generated tokens, got {len(generated)}"
+            )
+        if expected_ids is None:
+            expected_ids = generated
+        elif generated != expected_ids:
+            raise RuntimeError(
+                f"non-deterministic output in repetition {repetition}: "
+                f"expected {expected_ids}, got {generated}"
+            )
+        repetitions.append({
+            "repetition": repetition + 1,
+            "generation_seconds": elapsed,
+            "generated_tokens": len(generated),
+            "tokens_per_second": len(generated) / elapsed,
+            "generated_token_ids": generated,
+            "peak_allocated_mib": torch.cuda.max_memory_allocated(device) / 1024 ** 2,
+            "peak_reserved_mib": torch.cuda.max_memory_reserved(device) / 1024 ** 2,
+            "expert_cache": model.get_expert_cache_stats(),
+        })
+        print(
+            f"repetition {repetition + 1}/{args.repetitions}: "
+            f"{elapsed:.3f}s ({len(generated) / elapsed:.5f} tok/s)",
+            flush=True,
+        )
+
+    result = {
+        "model": args.model,
+        "model_path": str(model_path),
+        "revision": args.revision,
+        "device": torch.cuda.get_device_name(device),
+        "architecture": getattr(torch.cuda.get_device_properties(device), "gcnArchName", None),
+        "torch": torch.__version__,
+        "hip": torch.version.hip,
+        "dtype": args.dtype,
+        "prefetch_requested": not args.no_prefetch,
+        "prefetch": model.prefetching,
+        "expert_cache_gb": args.expert_cache_gb,
+        "expert_cache_backend": args.expert_cache_backend,
+        "prompt": args.prompt,
+        "input_tokens": input_ids.shape[-1],
+        "max_new_tokens": args.max_new_tokens,
+        "load_seconds": load_seconds,
+        "host_warmup_bytes": warmed_host_bytes,
+        "peak_process_rss_mib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
+        "median_generation_seconds": statistics.median(
+            item["generation_seconds"] for item in repetitions
+        ),
+        "median_tokens_per_second": statistics.median(
+            item["tokens_per_second"] for item in repetitions
+        ),
+        "repetitions": repetitions,
+        "generated_text": model.tokenizer.decode(expected_ids, skip_special_tokens=True),
+    }
+    payload = json.dumps(result, ensure_ascii=False)
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload + "\n", encoding="utf-8")
+    print("AIRLLM_EXPERT_CACHE_BENCHMARK=" + payload)
+    model.clear_expert_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/tests/test_automodel.py
+++ b/air_llm/tests/test_automodel.py
@@ -1,31 +1,31 @@
-import sys
+from types import SimpleNamespace
 import unittest
-
-#sys.path.insert(0, '../airllm')
+from unittest.mock import patch
 
 from ..airllm.auto_model import AutoModel
 
 
 
 class TestAutoModel(unittest.TestCase):
-    def setUp(self):
-        pass
-    def tearDown(self):
-        pass
-
     def test_auto_model_should_return_correct_model(self):
+        # Standard Transformers layouts intentionally use the generic streamer since 8f62eec;
+        # only non-standard layouts need an architecture-specific adapter. Mocking config also
+        # keeps this unit test deterministic and independent of Hub/network changes.
         mapping_dict = {
-            'garage-bAInd/Platypus2-7B': 'AirLLMLlama2',
-            'Qwen/Qwen-7B': 'AirLLMQWen',
-            'internlm/internlm-chat-7b': 'AirLLMInternLM',
-            'THUDM/chatglm3-6b-base': 'AirLLMChatGLM',
-            'baichuan-inc/Baichuan2-7B-Base': 'AirLLMBaichuan',
-            'mistralai/Mistral-7B-Instruct-v0.1': 'AirLLMMistral',
-            'mistralai/Mixtral-8x7B-v0.1': 'AirLLMMixtral'
+            'LlamaForCausalLM': 'AirLLMBaseModel',
+            'QWenLMHeadModel': 'AirLLMQWen',
+            'InternLMForCausalLM': 'AirLLMInternLM',
+            'ChatGLMForConditionalGeneration': 'AirLLMChatGLM',
+            'BaichuanForCausalLM': 'AirLLMBaichuan',
+            'MistralForCausalLM': 'AirLLMBaseModel',
+            'MixtralForCausalLM': 'AirLLMBaseModel',
         }
 
-
-        for k,v in mapping_dict.items():
-            module, cls = AutoModel.get_module_class(k)
-            self.assertEqual(cls, v, f"expecting {v}")
-
+        for architecture, expected in mapping_dict.items():
+            with self.subTest(architecture=architecture), patch(
+                "airllm.auto_model.AutoConfig.from_pretrained",
+                return_value=SimpleNamespace(architectures=[architecture]),
+            ):
+                module, cls = AutoModel.get_module_class("unused")
+            self.assertEqual(module, "airllm")
+            self.assertEqual(cls, expected)

--- a/air_llm/tests/test_compression.py
+++ b/air_llm/tests/test_compression.py
@@ -1,10 +1,12 @@
-import sys
 import unittest
 
 import torch
-sys.path.insert(0, '../airllm')
 
-from airllm import compress_layer_state_dict, uncompress_layer_state_dict
+from airllm.utils import (
+    bitsandbytes_installed,
+    compress_layer_state_dict,
+    uncompress_layer_state_dict,
+)
 
 
 
@@ -15,6 +17,10 @@ class TestCompression(unittest.TestCase):
     def tearDown(self):
         pass
 
+    @unittest.skipUnless(
+        torch.cuda.is_available() and bitsandbytes_installed,
+        "legacy compression test requires a GPU-capable BitsAndBytes installation",
+    )
     def test_should_compress_uncompress(self):
         #torch.manual_seed(0)
         a0 = torch.normal(0, 1, (32, 128), dtype=torch.float16).cuda()

--- a/air_llm/tests/test_expert_slot_cache.py
+++ b/air_llm/tests/test_expert_slot_cache.py
@@ -1,0 +1,231 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from airllm.airllm_base import AirLLMBaseModel
+from airllm.airllm_phimoe import AirLLMPhiMoE
+from airllm.expert_slot_cache import ExpertHostBank, ExpertSlotRuntime, FixedSlotLRU
+
+
+def _checkpoint_tensors(second_w1_shape=(3, 4)):
+    tensors = {}
+    for expert in range(2):
+        prefix = f"model.layers.0.block_sparse_moe.experts.{expert}"
+        w1_shape = (3, 4) if expert == 0 else second_w1_shape
+        tensors[f"{prefix}.w1.weight"] = torch.arange(
+            torch.tensor(w1_shape).prod(), dtype=torch.bfloat16
+        ).reshape(w1_shape) + expert
+        tensors[f"{prefix}.w2.weight"] = (
+            torch.arange(12, dtype=torch.bfloat16).reshape(4, 3) + expert
+        )
+        tensors[f"{prefix}.w3.weight"] = (
+            torch.arange(12, dtype=torch.bfloat16).reshape(3, 4) + expert
+        )
+    return tensors
+
+
+def _bank_args(root):
+    keys = {
+        0: {
+            expert: [
+                f"model.layers.0.block_sparse_moe.experts.{expert}.{projection}.weight"
+                for projection in ("w1", "w2", "w3")
+            ]
+            for expert in range(2)
+        }
+    }
+    prefixes = {
+        (0, expert): f"model.layers.0.block_sparse_moe.experts.{expert}"
+        for expert in range(2)
+    }
+    return root, ["model.layers.0"], keys, prefixes, torch.float16
+
+
+class TestFixedSlotLRU(unittest.TestCase):
+    def test_hit_refreshes_recency_and_reservation_reuses_fixed_slot(self):
+        lru = FixedSlotLRU(2)
+        first = lru.reserve((0, 0))
+        second = lru.reserve((0, 1))
+        self.assertEqual((first.slot, second.slot), (0, 1))
+
+        self.assertEqual(lru.lookup((0, 0)), 0)
+        third = lru.reserve((1, 0))
+        self.assertEqual(third.slot, 1)
+        self.assertEqual(third.evicted_key, (0, 1))
+        self.assertEqual(lru.keys(), ((0, 0), (1, 0)))
+
+    def test_active_experts_are_not_selected_as_victims(self):
+        lru = FixedSlotLRU(2)
+        lru.reserve((0, 0))
+        lru.reserve((0, 1))
+        self.assertIsNone(lru.reserve((0, 2), protected=((0, 0), (0, 1))))
+
+    def test_clear_reuses_all_preallocated_slot_ids(self):
+        lru = FixedSlotLRU(2)
+        lru.reserve((0, 0))
+        lru.reserve((0, 1))
+        lru.clear()
+        self.assertEqual(lru.resident_count, 0)
+        self.assertEqual(lru.reserve((1, 0)).slot, 0)
+
+
+class TestSlotBackendConfiguration(unittest.TestCase):
+    def test_unknown_backend_is_rejected_before_checkpoint_access(self):
+        with self.assertRaisesRegex(ValueError, "must be 'none' or 'slot'"):
+            AirLLMBaseModel("unused", expert_cache_backend="unknown")
+
+    def test_budget_requires_explicit_slot_backend(self):
+        with self.assertRaisesRegex(ValueError, "requires expert_cache_backend='slot'"):
+            AirLLMPhiMoE("unused", expert_cache_gb=0.75)
+
+    def test_slot_backend_requires_positive_budget(self):
+        with self.assertRaisesRegex(ValueError, "requires expert_cache_gb > 0"):
+            AirLLMPhiMoE("unused", expert_cache_backend="slot")
+
+    def test_slot_backend_rejects_cpu_device_before_checkpoint_access(self):
+        with self.assertRaisesRegex(ValueError, "requires a CUDA-compatible device"):
+            AirLLMPhiMoE(
+                "unused",
+                device="cpu",
+                expert_cache_gb=0.75,
+                expert_cache_backend="slot",
+            )
+
+    def test_slot_backend_rejects_unavailable_accelerator_before_checkpoint_access(self):
+        with patch("torch.cuda.is_available", return_value=False):
+            with self.assertRaisesRegex(ValueError, "requires a CUDA-compatible device"):
+                AirLLMPhiMoE(
+                    "unused",
+                    device="cuda:0",
+                    expert_cache_gb=0.75,
+                    expert_cache_backend="slot",
+                )
+
+
+class TestExpertHostBank(unittest.TestCase):
+    def test_normalizes_checkpoint_experts_into_contiguous_runtime_dtype_banks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = _checkpoint_tensors()
+            save_file(source, root / "model.layers.0.safetensors")
+
+            bank = ExpertHostBank(*_bank_args(root))
+
+            self.assertEqual(bank.expert_count, 2)
+            self.assertEqual(bank.source_tensor_reads, 6)
+            self.assertEqual(bank.projection_names, ("w1.weight", "w2.weight", "w3.weight"))
+            self.assertTrue(all(tensor.is_contiguous() for tensor in bank.banks.values()))
+            self.assertTrue(all(tensor.dtype == torch.float16 for tensor in bank.banks.values()))
+            actual = bank.tensors((0, 1))
+            for projection, tensor in zip(bank.projection_names, actual):
+                expected = source[
+                    f"model.layers.0.block_sparse_moe.experts.1.{projection}"
+                ].to(torch.float16)
+                torch.testing.assert_close(tensor, expected)
+
+    def test_rejects_non_uniform_expert_shapes_before_building_bank(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            save_file(_checkpoint_tensors(second_w1_shape=(2, 4)),
+                      root / "model.layers.0.safetensors")
+            with self.assertRaisesRegex(ValueError, "non-uniform w1.weight shape"):
+                ExpertHostBank(*_bank_args(root))
+
+    def test_rejects_missing_projection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = _checkpoint_tensors()
+            source.pop("model.layers.0.block_sparse_moe.experts.1.w3.weight")
+            save_file(source, root / "model.layers.0.safetensors")
+            args = list(_bank_args(root))
+            args[2][0][1].remove(
+                "model.layers.0.block_sparse_moe.experts.1.w3.weight"
+            )
+            with self.assertRaisesRegex(ValueError, "must contain exactly"):
+                ExpertHostBank(*args)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires a CUDA-compatible GPU")
+class TestExpertSlotRuntimeGPU(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        save_file(_checkpoint_tensors(), root / "model.layers.0.safetensors")
+        self.bank = ExpertHostBank(*_bank_args(root))
+        self.runtime = ExpertSlotRuntime(
+            self.bank,
+            self.bank.expert_bytes,
+            torch.device("cuda:0"),
+        )
+
+    def tearDown(self):
+        self.runtime.close()
+        del self.runtime
+        torch.cuda.empty_cache()
+        self.tmp.cleanup()
+
+    def _capture(self, expert_indices, admit):
+        captured = {}
+
+        def callback(expert_idx, weights):
+            captured[expert_idx] = tuple(weight.clone() for weight in weights)
+
+        self.runtime.execute(0, expert_indices, admit=admit, callback=callback)
+        torch.cuda.synchronize()
+        return captured
+
+    def test_evictions_reuse_fixed_addresses_and_preserve_values(self):
+        pointers = tuple(bank.data_ptr() for bank in self.runtime.cache_banks.values())
+        for expert_idx in (0, 1, 0):
+            captured = self._capture([expert_idx], admit=True)
+            for actual, expected in zip(captured[expert_idx], self.bank.tensors((0, expert_idx))):
+                torch.testing.assert_close(actual.cpu(), expected)
+        self.assertEqual(
+            pointers,
+            tuple(bank.data_ptr() for bank in self.runtime.cache_banks.values()),
+        )
+        self.assertEqual(self.runtime.stats()["evictions"], 2)
+
+    def test_two_lane_prefill_does_not_admit_scratch_experts(self):
+        captured = self._capture([0, 1], admit=False)
+        self.assertEqual(set(captured), {0, 1})
+        stats = self.runtime.stats()
+        self.assertEqual(stats["prefill_skips"], 2)
+        self.assertEqual(stats["resident_experts"], 0)
+        self.assertEqual(stats["generation_disk_expert_reads"], 0)
+
+    def test_reset_preserves_slots_and_clear_only_invalidates_residency(self):
+        pointers = tuple(bank.data_ptr() for bank in self.runtime.cache_banks.values())
+        self._capture([0], admit=True)
+        self._capture([0], admit=True)
+        self.assertEqual(self.runtime.stats()["hits"], 1)
+
+        self.runtime.reset_stats()
+        self.assertEqual(self.runtime.stats()["hits"], 0)
+        self.assertEqual(self.runtime.stats()["resident_experts"], 1)
+        self.runtime.clear()
+        self.assertEqual(self.runtime.stats()["resident_experts"], 0)
+        self.assertEqual(
+            pointers,
+            tuple(bank.data_ptr() for bank in self.runtime.cache_banks.values()),
+        )
+
+    def test_callback_failure_invalidates_residency_and_runtime_remains_usable(self):
+        def fail(_expert_idx, _weights):
+            raise RuntimeError("synthetic callback failure")
+
+        with self.assertRaisesRegex(RuntimeError, "synthetic callback failure"):
+            self.runtime.execute(0, [0], admit=True, callback=fail)
+
+        self.assertFalse(self.runtime._in_execute)
+        self.assertEqual(self.runtime.stats()["resident_experts"], 0)
+        captured = self._capture([1], admit=True)
+        self.assertEqual(set(captured), {1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/air_llm/tests/test_phimoe_adapter.py
+++ b/air_llm/tests/test_phimoe_adapter.py
@@ -1,0 +1,169 @@
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from airllm.airllm_base import AirLLMBaseModel
+from airllm.airllm_phimoe import AirLLMPhiMoE, PhiMoEStreamedExperts
+from airllm.auto_model import AutoModel
+
+
+def _config():
+    return types.SimpleNamespace(
+        hidden_size=4,
+        intermediate_size=3,
+        num_local_experts=3,
+        hidden_act="silu",
+    )
+
+
+class TestPhiMoEStreamedExperts(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(7)
+        self.experts = PhiMoEStreamedExperts(_config()).to_empty(device="cpu")
+        with torch.no_grad():
+            for parameter in self.experts.parameters():
+                parameter.uniform_(-0.25, 0.25)
+
+    def test_numeric_child_keys_match_published_checkpoint(self):
+        self.assertEqual(
+            set(self.experts.state_dict()),
+            {
+                f"{expert}.{projection}.weight"
+                for expert in range(3)
+                for projection in ("w1", "w2", "w3")
+            },
+        )
+
+    def test_output_matches_packed_bank_equations(self):
+        hidden = torch.randn(5, 4)
+        top_k_index = torch.tensor([[0, 2], [1, 0], [2, 1], [0, 1], [2, 0]])
+        top_k_weights = torch.softmax(torch.randn(5, 2), dim=-1)
+
+        actual = self.experts(hidden, top_k_index, top_k_weights)
+
+        gate_up = torch.stack([
+            torch.cat((self.experts[idx].w1.weight, self.experts[idx].w3.weight), dim=0)
+            for idx in range(3)
+        ])
+        down = torch.stack([self.experts[idx].w2.weight for idx in range(3)])
+        expected = torch.zeros_like(hidden)
+        expert_mask = F.one_hot(top_k_index, num_classes=3).permute(2, 1, 0)
+        for expert_idx in range(3):
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current = hidden[token_idx]
+            gate, up = F.linear(current, gate_up[expert_idx]).chunk(2, dim=-1)
+            current = F.linear(F.silu(gate) * up, down[expert_idx])
+            current = current * top_k_weights[token_idx, top_k_pos, None]
+            expected.index_add_(0, token_idx, current)
+
+        torch.testing.assert_close(actual, expected)
+
+    def test_only_routed_expert_modules_execute(self):
+        calls = [0, 0, 0]
+        hooks = []
+        for idx in range(3):
+            hooks.append(self.experts[idx].register_forward_hook(
+                lambda _module, _args, _out, expert_idx=idx: calls.__setitem__(
+                    expert_idx, calls[expert_idx] + 1
+                )
+            ))
+        try:
+            self.experts(
+                torch.randn(3, 4),
+                torch.tensor([[0, 2], [2, 0], [0, 2]]),
+                torch.full((3, 2), 0.5),
+            )
+        finally:
+            for hook in hooks:
+                hook.remove()
+        self.assertEqual(calls, [1, 0, 1])
+
+    def test_slot_runtime_uses_fixed_weight_views_without_calling_expert_modules(self):
+        class FakeSlotRuntime:
+            def __init__(self, experts):
+                self.experts = experts
+                self.calls = []
+
+            def execute(self, layer_idx, expert_indices, *, admit, callback):
+                self.calls.append((layer_idx, tuple(expert_indices), admit))
+                for expert_idx in expert_indices:
+                    expert = self.experts[expert_idx]
+                    callback(expert_idx, (
+                        expert.w1.weight,
+                        expert.w2.weight,
+                        expert.w3.weight,
+                    ))
+
+        hidden = torch.randn(1, 4)
+        indices = torch.tensor([[0, 2]])
+        weights = torch.tensor([[0.4, 0.6]])
+        expected = self.experts(hidden, indices, weights)
+
+        calls = [0, 0, 0]
+        hooks = [
+            self.experts[idx].register_forward_hook(
+                lambda _module, _args, _out, expert_idx=idx: calls.__setitem__(
+                    expert_idx, calls[expert_idx] + 1
+                )
+            )
+            for idx in range(3)
+        ]
+        runtime = FakeSlotRuntime(self.experts)
+        self.experts._airllm_slot_runtime = runtime
+        self.experts._airllm_layer_idx = 7
+        try:
+            actual = self.experts(hidden, indices, weights)
+        finally:
+            for hook in hooks:
+                hook.remove()
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(calls, [0, 0, 0])
+        self.assertEqual(runtime.calls, [(7, (0, 2), True)])
+
+    def test_automodel_selects_phimoe_adapter(self):
+        config = types.SimpleNamespace(architectures=["PhiMoEForCausalLM"])
+        with patch("airllm.auto_model.AutoConfig.from_pretrained", return_value=config):
+            module, class_name = AutoModel.get_module_class("unused")
+        self.assertEqual(module, "airllm")
+        self.assertEqual(class_name, "AirLLMPhiMoE")
+
+    def test_transformers_5_mlp_layout_gets_checkpoint_aliases(self):
+        class PackedExperts(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate_up_proj = nn.Parameter(torch.empty(3, 6, 4, device="meta"))
+                self.down_proj = nn.Parameter(torch.empty(3, 4, 3, device="meta"))
+
+        sparse_moe = nn.Module()
+        sparse_moe.router = nn.Linear(4, 3, bias=False, device="meta")
+        sparse_moe.experts = PackedExperts()
+        layer = nn.Module()
+        layer.mlp = sparse_moe
+        decoder = nn.Module()
+        decoder.layers = nn.ModuleList([layer])
+        root = nn.Module()
+        root.model = decoder
+
+        wrapper = object.__new__(AirLLMPhiMoE)
+        wrapper.model = root
+        wrapper.config = _config()
+        with patch.object(AirLLMBaseModel, "init_model"):
+            wrapper.init_model()
+
+        self.assertIs(layer.mlp, layer.block_sparse_moe)
+        self.assertIs(layer.mlp.router, layer.block_sparse_moe.gate)
+        self.assertIsInstance(layer.mlp.experts, PhiMoEStreamedExperts)
+        self.assertEqual(wrapper.config._experts_implementation, "eager")
+        self.assertIs(
+            root.get_submodule("model.layers.0.block_sparse_moe.experts.0"),
+            layer.mlp.experts[0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a [FreeToken-inspired](https://arxiv.org/abs/2608.16157), opt-in fixed-slot GPU expert-streaming runtime, initially supporting PhiMoE.

On an AMD Radeon RX 6400, generation improved from 366.74 seconds to 2.64 seconds—approximately **139× faster**—with identical token IDs. This is an independent AirLLM implementation; no FreeToken code is reused.

The runtime:

- Builds a normalized CPU host bank for expert weights.
- Keeps dense weights resident on the GPU.
- Reuses preallocated GPU slots through LRU replacement.
- Uses scratch slots during multi-expert prefill.
- Eliminates generation-time expert disk reads and allocator churn.

## Usage

```python
model = AutoModel.from_pretrained(
    model_path,
    expert_cache_backend="slot",
    expert_cache_gb=0.75,
)
```

The slot backend is currently supported by the new PhiMoE adapter and requires a CUDA- or ROCm-compatible device.

## Changes

- Add AirLLMPhiMoE and automatic architecture selection.
- Add the fixed-slot expert runtime and CPU host bank.
- Preserve AirLLM’s existing streaming behavior by default.
- Add cache lifecycle statistics and a reproducible benchmark.
- Add CPU and GPU coverage for slot reuse, eviction, prefill, and failure recovery.

## Validation

Benchmarked with [Microsoft Phi-tiny-MoE-instruct](https://huggingface.co/microsoft/Phi-tiny-MoE-instruct/tree/2fe50e88d0e2a5a132563815686ea0dcc8e252b5) at revision `2fe50e8`.

### Test system

- GPU: AMD Radeon RX 6400 (`gfx1034`, 4 GiB VRAM)
- CPU: AMD Ryzen 5 3600, 6 cores / 12 threads
- Host memory: 31 GiB
- Storage: NVMe, ext4
- PyTorch: `2.12.0+rocm7.14.0`
- Runtime dtype: `float16`

### Resource usage

- Hugging Face checkpoint: approximately 7.0 GiB
- AirLLM split checkpoint: approximately 7.0 GiB
- Measured disk usage with both retained: approximately 14 GiB
- CPU expert host bank: 5.25 GiB for 512 experts
- Peak process RAM: 7.60 GiB
- Dense GPU weights: 1.74 GiB
- Expert-slot budget: 0.75 GiB
- GPU slots: 73 resident slots plus 2 scratch slots
- Peak reserved VRAM: 2.56 GiB
- Expert disk reads during generation: 0

Generation improved from 366.74 seconds to 2.64 seconds—approximately **139× faster**—while producing identical token IDs.

The final smoke test generated 8 tokens in 2.73 seconds at 2.93 tokens/second. The ROCm suite discovered 37 tests: 36 passed and one optional BitsAndBytes test was skipped.
