### PR TITLE
docs: remove Bloome recommendation and Sponsors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@
 
 * [Best AI Facial Expression Editor](https://crazyfaceai.com)
 
-* [Bloome — build & run AI agent teams in the cloud, zero setup](https://bloome.im/app?ref=G6BYnov0&utm_medium=github&utm_source=lyogavin-airllm-ivor-202606)
-
 ## Updates
 [2026/08] **Qwen3.8-Flash-Next** support: Qwen's 125B MoE flagship (`Qwen4ExpForConditionalGeneration`) with a ~51B n-gram embedding runs in **5.95GB** of VRAM, measured end to end on one RTX 4090. The n-gram table is file-mapped on the host (a 64GB machine is enough); decoder layers stream. Needs a `transformers` build with in-tree `qwen4_exp` (`pip install git+https://github.com/huggingface/transformers.git` today) and ~360GB of checkpoint disk (`delete_original=True` reclaims the originals after the split).
 
@@ -369,19 +367,6 @@ BibTex entry:
   year = {2023},
 }
 ```
-
-
-## Sponsors
-
-<a href="https://bloome.im/app?ref=G6BYnov0&utm_medium=github&utm_source=lyogavin-airllm-ivor-202606">
-  <img src="https://github.com/lyogavin/airllm/blob/main/assets/bloome.png?raw=true" alt="Bloome — Run AI Agent Teams in the Cloud" width="50%" />
-</a>
-
-### Run AI Agent Teams in the Cloud — Bloome
-
-Bloome is an AI-agent IM platform: build and run AI agent teams in the cloud with zero setup. Add a skill as an agent in a group chat, run it in one click from web or mobile, and share it with your team — think of it as a group chat where your AI assistants are teammates you can @mention and assign tasks to.
-
-👉 Try [Bloome](https://bloome.im/app?ref=G6BYnov0&utm_medium=github&utm_source=lyogavin-airllm-ivor-202606)
 
 
 ## Contribution 


### PR DESCRIPTION
## Summary
- Drop the Bloome link from **AI Agents Recommendation**.
- Remove the **Sponsors** section (Bloome logo and copy).

## Test plan
- [ ] README renders on GitHub without those two blocks
- [ ] Remaining recommendation links (Godmode, CrazyFace) still work


Made with [Cursor](https://cursor.com)