### PR TITLE
Add CLI and interactive terminal chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,48 @@
 
 ### 1. Install package
 
-First, install the airllm pip package.
-
 ```bash
 pip install airllm
 ```
 
-### 2. Inference
+### 2. Interactive Chat & CLI 
 
-Then, initialize AirLLMLlama2, pass in the huggingface repo ID of the model being used, or the local path, and inference can be performed similar to a regular transformer model.
+Chat directly with 70B+ models in your terminal with live streaming responses:
 
-(*You can also specify the path to save the splitted layered model through **layer_shards_saving_path** when init AirLLMLlama2.*
+```bash
+# Chat immediately (downloads and shards automatically)
+airllm run llama3:70b
+
+# Chat with DeepSeek, Qwen 2.5, Mistral, etc.
+airllm run deepseek-r1:70b
+airllm run qwen2.5:72b
+
+# View all friendly model aliases
+airllm aliases
+
+# List downloaded models and their disk size
+airllm list
+
+# Pre-download and shard a model ahead of time
+airllm pull llama3:70b
+
+# Inspect model architecture and context length
+airllm show llama3:70b
+
+# Free up disk space
+airllm rm llama3:70b
+```
+
+**Inside the interactive terminal chat:**
+* Real-time token streaming as words are generated.
+* Multi-turn conversational memory.
+* Quick slash commands: `/help`, `/clear` (reset context), `/system <prompt>` (update system instructions), `/history` (review conversation), `/stats` (toggle speed tokens/s), `/bye` (exit).
+
+---
+
+### 3. Python API (Optional)
+
+If you prefer writing custom Python scripts, you can continue using `AutoModel`:
 
 ```python
 from airllm import AutoModel

--- a/air_llm/airllm/__init__.py
+++ b/air_llm/airllm/__init__.py
@@ -44,3 +44,16 @@ else:
                 f"This only affects that specific model family; the generic streaming path still works."
             )
 
+    from .chat import InteractiveChatSession
+    from .models import (
+        resolve_model_name,
+        list_local_models,
+        remove_model_cache,
+        get_model_info,
+        MODEL_ALIASES,
+    )
+
+    def cli_main():
+        from .cli import main
+        return main()
+

--- a/air_llm/airllm/__main__.py
+++ b/air_llm/airllm/__main__.py
@@ -1,0 +1,4 @@
+from airllm.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/airllm/chat.py
+++ b/air_llm/airllm/chat.py
@@ -1,0 +1,250 @@
+import sys
+import time
+import threading
+from typing import List, Dict, Optional, Any
+from transformers import TextIteratorStreamer
+
+# ANSI Terminal Color Helpers
+class Colors:
+    HEADER = '\033[95m'
+    BLUE = '\033[94m'
+    CYAN = '\033[96m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    BOLD = '\033[1m'
+    DIM = '\033[2m'
+    RESET = '\033[0m'
+
+    @classmethod
+    def enable_windows_ansi(cls):
+        """Enable ANSI escape codes in Windows cmd/PowerShell console."""
+        if sys.platform == "win32":
+            try:
+                import ctypes
+                kernel32 = ctypes.windll.kernel32
+                handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+                mode = ctypes.c_ulong()
+                kernel32.GetConsoleMode(handle, ctypes.byref(mode))
+                mode.value |= 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                kernel32.SetConsoleMode(handle, mode)
+            except Exception:
+                pass
+
+
+Colors.enable_windows_ansi()
+
+
+DEFAULT_SYSTEM_PROMPT = "You are a helpful, respectful, and honest AI assistant."
+
+
+class InteractiveChatSession:
+    """Manages an interactive multi-turn terminal chat session for an AirLLM model."""
+
+    def __init__(
+        self,
+        model: Any,
+        model_name: str,
+        system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        max_new_tokens: int = 512,
+        show_stats: bool = True,
+    ):
+        self.model = model
+        self.model_name = model_name
+        self.system_prompt = system_prompt
+        self.max_new_tokens = max_new_tokens
+        self.show_stats = show_stats
+        self.messages: List[Dict[str, str]] = []
+        self._init_history()
+
+    def _init_history(self):
+        self.messages = []
+        if self.system_prompt:
+            self.messages.append({"role": "system", "content": self.system_prompt})
+
+    def print_banner(self):
+        print(f"\n{Colors.CYAN}{Colors.BOLD}======================================================{Colors.RESET}")
+        print(f"  {Colors.BOLD}AirLLM Interactive Chat{Colors.RESET} - {Colors.GREEN}{self.model_name}{Colors.RESET}")
+        print(f"  Type your message and press {Colors.BOLD}Enter{Colors.RESET}.")
+        print(f"  Commands: {Colors.YELLOW}/help{Colors.RESET}, {Colors.YELLOW}/clear{Colors.RESET}, {Colors.YELLOW}/history{Colors.RESET}, {Colors.YELLOW}/stats{Colors.RESET}, {Colors.YELLOW}/bye{Colors.RESET}")
+        print(f"{Colors.CYAN}{Colors.BOLD}======================================================{Colors.RESET}\n")
+
+    def print_help(self):
+        print(f"\n{Colors.BOLD}Available Commands:{Colors.RESET}")
+        print(f"  {Colors.YELLOW}/bye{Colors.RESET} or {Colors.YELLOW}/exit{Colors.RESET}   : Exit the chat session")
+        print(f"  {Colors.YELLOW}/clear{Colors.RESET}          : Reset the conversation history")
+        print(f"  {Colors.YELLOW}/history{Colors.RESET}        : Display past turns in this conversation")
+        print(f"  {Colors.YELLOW}/system <msg>{Colors.RESET}   : Set a new system prompt")
+        print(f"  {Colors.YELLOW}/stats{Colors.RESET}          : Toggle generation speed statistics")
+        print(f"  {Colors.YELLOW}/help{Colors.RESET}           : Show this help message\n")
+
+    def print_history(self):
+        print(f"\n{Colors.BOLD}--- Conversation History ---{Colors.RESET}")
+        for msg in self.messages:
+            role = msg["role"].upper()
+            content = msg["content"]
+            if role == "SYSTEM":
+                print(f"{Colors.YELLOW}[SYSTEM]{Colors.RESET} {content}")
+            elif role == "USER":
+                print(f"{Colors.CYAN}[USER]{Colors.RESET} {content}")
+            else:
+                print(f"{Colors.GREEN}[ASSISTANT]{Colors.RESET} {content}")
+        print(f"{Colors.BOLD}----------------------------{Colors.RESET}\n")
+
+    def format_prompt(self) -> str:
+        """Format the message history using the tokenizer chat template or standard fallback."""
+        tokenizer = self.model.tokenizer
+
+        # Try tokenizer's built-in chat template
+        if hasattr(tokenizer, "apply_chat_template") and getattr(tokenizer, "chat_template", None):
+            try:
+                return tokenizer.apply_chat_template(
+                    self.messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            except Exception:
+                pass
+
+        # Fallback format
+        lines = []
+        for msg in self.messages:
+            role = msg["role"]
+            content = msg["content"]
+            if role == "system":
+                lines.append(f"System: {content}\n")
+            elif role == "user":
+                lines.append(f"User: {content}\n")
+            elif role == "assistant":
+                lines.append(f"Assistant: {content}\n")
+        lines.append("Assistant: ")
+        return "".join(lines)
+
+    def stream_response(self, prompt_text: str) -> str:
+        """Stream model generation tokens in real time to stdout and return full response."""
+        tokenizer = self.model.tokenizer
+        max_len = getattr(self.model, "max_seq_len", 512)
+
+        input_tokens = tokenizer(
+            prompt_text,
+            return_tensors="pt",
+            return_attention_mask=False,
+            truncation=True,
+            max_length=max_len,
+        )
+
+        input_ids = input_tokens["input_ids"]
+        # Move to model's execution device
+        running_device = getattr(self.model, "running_device", "cuda:0")
+        try:
+            input_ids = input_ids.to(running_device)
+        except Exception:
+            pass
+
+        streamer = TextIteratorStreamer(
+            tokenizer,
+            skip_prompt=True,
+            skip_special_tokens=True,
+        )
+
+        generation_kwargs = dict(
+            input_ids=input_ids,
+            streamer=streamer,
+            max_new_tokens=self.max_new_tokens,
+            use_cache=True,
+            return_dict_in_generate=True,
+        )
+
+        # Launch generation in background thread
+        thread = threading.Thread(target=self.model.generate, kwargs=generation_kwargs)
+        start_time = time.time()
+        thread.start()
+
+        full_response = []
+        token_count = 0
+
+        # Stream tokens live
+        for new_text in streamer:
+            sys.stdout.write(new_text)
+            sys.stdout.flush()
+            full_response.append(new_text)
+            token_count += 1
+
+        thread.join()
+        elapsed = time.time() - start_time
+        print()  # Newline after stream ends
+
+        response_str = "".join(full_response).strip()
+
+        if self.show_stats and elapsed > 0 and token_count > 0:
+            speed = token_count / elapsed
+            print(f"{Colors.DIM}({token_count} tokens, {elapsed:.2f}s, {speed:.2f} tokens/s){Colors.RESET}")
+
+        return response_str
+
+    def step(self, user_input: str) -> bool:
+        """Process a single turn. Returns False if the session should exit."""
+        text = user_input.strip()
+        if not text:
+            return True
+
+        # Check slash commands
+        if text.lower() in ("/bye", "/exit", "/quit"):
+            print(f"\n{Colors.CYAN}Goodbye!{Colors.RESET}\n")
+            return False
+
+        if text.lower() == "/clear":
+            self._init_history()
+            print(f"{Colors.YELLOW}Conversation history cleared.{Colors.RESET}")
+            return True
+
+        if text.lower() == "/history":
+            self.print_history()
+            return True
+
+        if text.lower() == "/stats":
+            self.show_stats = not self.show_stats
+            state = "enabled" if self.show_stats else "disabled"
+            print(f"{Colors.YELLOW}Generation stats {state}.{Colors.RESET}")
+            return True
+
+        if text.lower() == "/help":
+            self.print_help()
+            return True
+
+        if text.lower().startswith("/system"):
+            new_sys = text[len("/system"):].strip()
+            if new_sys:
+                self.system_prompt = new_sys
+                self._init_history()
+                print(f"{Colors.YELLOW}System prompt updated and conversation reset.{Colors.RESET}")
+            else:
+                print(f"{Colors.YELLOW}Current system prompt:{Colors.RESET} {self.system_prompt}")
+            return True
+
+        # Process user message
+        self.messages.append({"role": "user", "content": text})
+        prompt = self.format_prompt()
+
+        try:
+            response = self.stream_response(prompt)
+            self.messages.append({"role": "assistant", "content": response})
+        except KeyboardInterrupt:
+            print(f"\n{Colors.YELLOW}[Generation interrupted by user]{Colors.RESET}")
+        except Exception as e:
+            print(f"\n{Colors.RED}Generation Error: {e}{Colors.RESET}")
+
+        return True
+
+    def start_loop(self):
+        """Start the interactive REPL prompt loop."""
+        self.print_banner()
+        while True:
+            try:
+                prompt_prefix = f"{Colors.BOLD}{Colors.CYAN}>>> {Colors.RESET}"
+                user_input = input(prompt_prefix)
+                if not self.step(user_input):
+                    break
+            except (KeyboardInterrupt, EOFError):
+                print(f"\n\n{Colors.CYAN}Exiting AirLLM chat.{Colors.RESET}")
+                break

--- a/air_llm/airllm/cli.py
+++ b/air_llm/airllm/cli.py
@@ -1,0 +1,218 @@
+import argparse
+import sys
+import os
+from typing import Optional
+
+from .models import (
+    resolve_model_name,
+    list_local_models,
+    remove_model_cache,
+    get_model_info,
+    MODEL_ALIASES,
+)
+from .chat import InteractiveChatSession, Colors
+
+
+def print_logo():
+    print(f"""{Colors.CYAN}{Colors.BOLD}
+     _    _      _     _     __  __ 
+    / \  (_)_ __| |   | |   |  \/  |
+   / _ \ | | '__| |   | |   | |\/| |
+  / ___ \| | |  | |___| |___| |  | |
+ /_/   \_\_|_|  |_____|_____|_|  |_|
+{Colors.RESET}{Colors.DIM} Run 70B+ LLMs without massive VRAM | Easy CLI & Chat{Colors.RESET}
+""")
+
+
+def cmd_run(args):
+    """Load model and launch interactive terminal chat session."""
+    print_logo()
+    model_name_or_path = resolve_model_name(args.model)
+    display_name = args.model
+
+    print(f"[*] Initializing model: {Colors.BOLD}{display_name}{Colors.RESET}")
+    if model_name_or_path != display_name:
+        print(f"[*] Resolved to HuggingFace repo: {Colors.DIM}{model_name_or_path}{Colors.RESET}")
+
+    from .auto_model import AutoModel
+
+    kwargs = {
+        "device": args.device,
+        "max_seq_len": args.max_seq_len,
+    }
+    if args.compression:
+        kwargs["compression"] = args.compression
+    if args.hf_token:
+        kwargs["hf_token"] = args.hf_token
+
+    try:
+        print(f"[*] Loading layers (streaming from disk on demand)...")
+        model = AutoModel.from_pretrained(model_name_or_path, **kwargs)
+    except Exception as e:
+        print(f"\n{Colors.RED}[!] Failed to load model '{model_name_or_path}': {e}{Colors.RESET}")
+        sys.exit(1)
+
+    session = InteractiveChatSession(
+        model=model,
+        model_name=display_name,
+        system_prompt=args.system or "You are a helpful, respectful, and honest AI assistant.",
+        max_new_tokens=args.max_new_tokens,
+        show_stats=not args.no_stats,
+    )
+    session.start_loop()
+
+
+def cmd_pull(args):
+    """Download and split a model into layer shards ahead of time."""
+    print_logo()
+    model_name_or_path = resolve_model_name(args.model)
+    display_name = args.model
+
+    print(f"[*] Pulling and sharding model: {Colors.BOLD}{display_name}{Colors.RESET}")
+    if model_name_or_path != display_name:
+        print(f"[*] Resolved to HuggingFace repo: {Colors.DIM}{model_name_or_path}{Colors.RESET}")
+
+    from .utils import find_or_create_local_splitted_path
+
+    try:
+        model_path, split_path = find_or_create_local_splitted_path(
+            model_name_or_path,
+            compression=args.compression,
+            hf_token=args.hf_token,
+        )
+        print(f"\n{Colors.GREEN}[+] Model successfully pulled and sharded!{Colors.RESET}")
+        print(f"    Base checkpoint: {model_path}")
+        print(f"    Shards cache:    {split_path}")
+        print(f"\nYou can now chat with it anytime using:")
+        print(f"    {Colors.CYAN}airllm run {display_name}{Colors.RESET}\n")
+    except Exception as e:
+        print(f"\n{Colors.RED}[!] Failed to pull model '{display_name}': {e}{Colors.RESET}")
+        sys.exit(1)
+
+
+def cmd_list(args):
+    """List local cached and sharded models."""
+    models = list_local_models()
+    if not models:
+        print("\nNo cached models found in HuggingFace/AirLLM storage.")
+        print(f"To run or download a model, use: {Colors.CYAN}airllm run <model_name>{Colors.RESET}\n")
+        return
+
+    print(f"\n{Colors.BOLD}{'NAME':<24} {'REPO ID':<38} {'SHARDS':<10} {'SIZE':<10}{Colors.RESET}")
+    print("-" * 86)
+    for m in models:
+        shards_info = "Ready" if m["sharded"] else "Not split"
+        shards_color = Colors.GREEN if m["sharded"] else Colors.YELLOW
+        print(f"{Colors.CYAN}{m['name']:<24}{Colors.RESET} {m['repo_id']:<38} {shards_color}{shards_info:<10}{Colors.RESET} {m['size_formatted']:<10}")
+    print()
+
+
+def cmd_show(args):
+    """Show detailed model configuration and architecture information."""
+    info = get_model_info(args.model, hf_token=args.hf_token)
+    if "error" in info:
+        print(f"\n{Colors.RED}[!] Could not retrieve model info: {info['error']}{Colors.RESET}\n")
+        return
+
+    print(f"\n{Colors.BOLD}Model Information:{Colors.RESET}")
+    print(f"  Name:           {Colors.CYAN}{info['name']}{Colors.RESET}")
+    print(f"  Repo ID:        {info['repo_id']}")
+    print(f"  Architecture:   {info['architecture']}")
+    print(f"  Layers:         {info['layers']}")
+    print(f"  Hidden Size:    {info['hidden_size']}")
+    print(f"  Attention Heads:{info['attention_heads']}")
+    print(f"  Context Window: {info['context_length']}")
+    print(f"  Precision:      {info['dtype']}\n")
+
+
+def cmd_rm(args):
+    """Delete model cache and splitted shards to free disk space."""
+    resolved = resolve_model_name(args.model)
+    if not args.yes:
+        confirm = input(f"Are you sure you want to delete cache for '{args.model}' ({resolved})? [y/N]: ").strip().lower()
+        if confirm != "y":
+            print("Deletion cancelled.")
+            return
+
+    success = remove_model_cache(args.model)
+    if success:
+        print(f"{Colors.GREEN}[+] Model cache for '{args.model}' deleted successfully.{Colors.RESET}")
+    else:
+        print(f"{Colors.YELLOW}[!] Model cache for '{args.model}' not found or already deleted.{Colors.RESET}")
+
+
+def cmd_aliases(args):
+    """List available friendly model aliases."""
+    print(f"\n{Colors.BOLD}{'ALIAS':<22} {'HUGGINGFACE REPO':<50}{Colors.RESET}")
+    print("-" * 74)
+    for alias, repo in sorted(MODEL_ALIASES.items()):
+        print(f"{Colors.CYAN}{alias:<22}{Colors.RESET} {repo:<50}")
+    print(f"\nYou can run any of these with: {Colors.CYAN}airllm run <alias>{Colors.RESET}")
+    print(f"Or pass any arbitrary HuggingFace repo ID: {Colors.CYAN}airllm run <org/repo>{Colors.RESET}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="airllm",
+        description="AirLLM: Run 70B+ LLMs without needing massive GPU memory. Interactive CLI & Chat like Ollama.",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand", help="Subcommand to execute")
+
+    # run
+    p_run = subparsers.add_parser("run", help="Run a model and enter interactive chat session")
+    p_run.add_argument("model", help="Model alias (e.g. llama3:70b, deepseek-r1:70b, qwen2.5:72b) or HuggingFace repo ID")
+    p_run.add_argument("-c", "--compression", choices=["4bit", "8bit"], default=None, help="Block-wise quantization for on-disk shards (requires bitsandbytes)")
+    p_run.add_argument("-d", "--device", default="cuda:0", help="Execution device (default: cuda:0)")
+    p_run.add_argument("--max-seq-len", type=int, default=512, help="Maximum sequence length (default: 512)")
+    p_run.add_argument("--max-new-tokens", type=int, default=512, help="Max new tokens generated per turn (default: 512)")
+    p_run.add_argument("--system", type=str, default=None, help="Custom system prompt")
+    p_run.add_argument("--no-stats", action="store_true", help="Hide generation speed stats (tokens/s)")
+    p_run.add_argument("--hf-token", type=str, default=None, help="Hugging Face API token for gated models")
+    p_run.set_defaults(func=cmd_run)
+
+    # pull
+    p_pull = subparsers.add_parser("pull", help="Download and shard a model in advance")
+    p_pull.add_argument("model", help="Model alias or HuggingFace repo ID")
+    p_pull.add_argument("-c", "--compression", choices=["4bit", "8bit"], default=None, help="Compression type (4bit or 8bit)")
+    p_pull.add_argument("--hf-token", type=str, default=None, help="Hugging Face token")
+    p_pull.set_defaults(func=cmd_pull)
+
+    # list / ls
+    p_list = subparsers.add_parser("list", aliases=["ls"], help="List local cached models and shard readiness")
+    p_list.set_defaults(func=cmd_list)
+
+    # show
+    p_show = subparsers.add_parser("show", help="Show architecture and context info for a model")
+    p_show.add_argument("model", help="Model alias or repo ID")
+    p_show.add_argument("--hf-token", type=str, default=None, help="Hugging Face token")
+    p_show.set_defaults(func=cmd_show)
+
+    # rm
+    p_rm = subparsers.add_parser("rm", help="Remove cached model layers to free disk space")
+    p_rm.add_argument("model", help="Model alias or repo ID to remove")
+    p_rm.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
+    p_rm.set_defaults(func=cmd_rm)
+
+    # aliases
+    p_aliases = subparsers.add_parser("aliases", help="List available friendly model aliases")
+    p_aliases.set_defaults(func=cmd_aliases)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    if len(sys.argv) == 1:
+        print_logo()
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/air_llm/airllm/models.py
+++ b/air_llm/airllm/models.py
@@ -1,0 +1,207 @@
+import os
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+from huggingface_hub import constants as hf_constants
+from transformers import AutoConfig
+
+# Curated registry of friendly aliases (similar to Ollama model tags)
+MODEL_ALIASES: Dict[str, str] = {
+    # Llama 3 / 3.1 / 3.2 / 3.3
+    "llama3": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "llama3:8b": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "llama3:70b": "meta-llama/Meta-Llama-3-70B-Instruct",
+    "llama3.1": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "llama3.1:8b": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "llama3.1:70b": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+    "llama3.1:405b": "meta-llama/Meta-Llama-3.1-405B-Instruct",
+    "llama3.2:1b": "meta-llama/Llama-3.2-1B-Instruct",
+    "llama3.2:3b": "meta-llama/Llama-3.2-3B-Instruct",
+    "llama3.3": "meta-llama/Llama-3.3-70B-Instruct",
+    "llama3.3:70b": "meta-llama/Llama-3.3-70B-Instruct",
+
+    # DeepSeek
+    "deepseek-v3": "deepseek-ai/DeepSeek-V3",
+    "deepseek-r1": "deepseek-ai/DeepSeek-R1",
+    "deepseek-r1:70b": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    "deepseek-r1:32b": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "deepseek-r1:14b": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+    "deepseek-r1:8b": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
+    "deepseek-r1:7b": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "deepseek-r1:1.5b": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+
+    # Qwen 2.5
+    "qwen2.5": "Qwen/Qwen2.5-7B-Instruct",
+    "qwen2.5:7b": "Qwen/Qwen2.5-7B-Instruct",
+    "qwen2.5:14b": "Qwen/Qwen2.5-14B-Instruct",
+    "qwen2.5:32b": "Qwen/Qwen2.5-32B-Instruct",
+    "qwen2.5:72b": "Qwen/Qwen2.5-72B-Instruct",
+    "qwen2.5-coder:7b": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "qwen2.5-coder:32b": "Qwen/Qwen2.5-Coder-32B-Instruct",
+
+    # Mistral & Mixtral
+    "mistral": "mistralai/Mistral-7B-Instruct-v0.3",
+    "mistral:7b": "mistralai/Mistral-7B-Instruct-v0.3",
+    "mixtral": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "mixtral:8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "mixtral:8x22b": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+
+    # Kimi / Moonshot
+    "kimi-k3": "MoonshotAI/Kimi-K3",
+
+    # Popular benchmark / open models
+    "platypus2:70b": "garage-bAInd/Platypus2-70B-instruct",
+}
+
+
+def resolve_model_name(name_or_alias: str) -> str:
+    """Resolve a friendly alias (e.g. 'llama3:70b') to HuggingFace repo ID or return path as-is."""
+    clean_name = name_or_alias.strip()
+    return MODEL_ALIASES.get(clean_name.lower(), clean_name)
+
+
+def get_alias_for_repo(repo_id: str) -> Optional[str]:
+    """Find any friendly alias pointing to this repository ID."""
+    clean_repo = repo_id.strip()
+    for alias, target in MODEL_ALIASES.items():
+        if target.lower() == clean_repo.lower():
+            return alias
+    return None
+
+
+def format_size(bytes_size: int) -> str:
+    """Format bytes into human-readable string (e.g. 14.2 GB)."""
+    if bytes_size <= 0:
+        return "0 B"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    i = 0
+    size = float(bytes_size)
+    while size >= 1024.0 and i < len(units) - 1:
+        size /= 1024.0
+        i += 1
+    return f"{size:.1f} {units[i]}"
+
+
+def get_dir_size(path: Path) -> int:
+    """Calculate recursive directory size in bytes."""
+    total = 0
+    try:
+        for entry in os.scandir(path):
+            if entry.is_symlink():
+                continue
+            if entry.is_file():
+                total += entry.stat().st_size
+            elif entry.is_dir():
+                total += get_dir_size(Path(entry.path))
+    except (OSError, PermissionError):
+        pass
+    return total
+
+
+def get_hf_hub_cache_dir() -> Path:
+    """Return the base path for HuggingFace hub cache."""
+    return Path(hf_constants.HF_HUB_CACHE)
+
+
+def list_local_models() -> List[Dict[str, Any]]:
+    """Scan local Hugging Face and AirLLM cache directories for downloaded/sharded models."""
+    hub_dir = get_hf_hub_cache_dir()
+    models = []
+    if not hub_dir.exists():
+        return models
+
+    # Hugging Face hub folders follow: models--<org>--<repo>
+    for entry in hub_dir.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("models--"):
+            continue
+
+        parts = entry.name[len("models--"):].split("--")
+        repo_id = "/".join(parts) if len(parts) >= 2 else parts[0]
+        alias = get_alias_for_repo(repo_id)
+
+        # Check snapshots and split folders
+        snapshots_dir = entry / "snapshots"
+        has_snapshot = snapshots_dir.exists() and any(snapshots_dir.iterdir())
+        
+        # Check if splitted_model exists in snapshot or custom folder
+        split_dirs = []
+        if has_snapshot:
+            for snap in snapshots_dir.iterdir():
+                if snap.is_dir():
+                    for sub in snap.iterdir():
+                        if sub.is_dir() and sub.name.startswith("splitted_model"):
+                            split_dirs.append(sub)
+
+        total_size = get_dir_size(entry)
+        last_modified = entry.stat().st_mtime
+
+        models.append({
+            "name": alias or repo_id,
+            "repo_id": repo_id,
+            "path": str(entry),
+            "size": total_size,
+            "size_formatted": format_size(total_size),
+            "sharded": len(split_dirs) > 0,
+            "shards_count": len(split_dirs),
+            "modified": last_modified,
+        })
+
+    models.sort(key=lambda m: m["modified"], reverse=True)
+    return models
+
+
+def remove_model_cache(name_or_alias: str) -> bool:
+    """Delete the model cache (and its shards) from the local system."""
+    repo_id = resolve_model_name(name_or_alias)
+    hub_dir = get_hf_hub_cache_dir()
+
+    # Form the folder name 'models--org--repo'
+    parts = repo_id.replace("/", "--")
+    folder_name = f"models--{parts}"
+    target = hub_dir / folder_name
+
+    if target.exists() and target.is_dir():
+        shutil.rmtree(target, ignore_errors=True)
+        return True
+
+    # If user provided direct path
+    p = Path(name_or_alias)
+    if p.exists() and p.is_dir():
+        shutil.rmtree(p, ignore_errors=True)
+        return True
+
+    return False
+
+
+def get_model_info(name_or_alias: str, hf_token: Optional[str] = None) -> Dict[str, Any]:
+    """Retrieve metadata and configuration details about a model."""
+    repo_id = resolve_model_name(name_or_alias)
+    token_kwargs = {"token": hf_token} if hf_token else {}
+
+    try:
+        config = AutoConfig.from_pretrained(repo_id, trust_remote_code=True, **token_kwargs)
+        cfg_dict = config.to_dict()
+    except Exception as e:
+        return {
+            "name": name_or_alias,
+            "repo_id": repo_id,
+            "error": str(e)
+        }
+
+    arch = cfg_dict.get("architectures", ["Unknown"])[0] if cfg_dict.get("architectures") else "Unknown"
+    num_layers = cfg_dict.get("num_hidden_layers", cfg_dict.get("n_layer", "N/A"))
+    hidden_size = cfg_dict.get("hidden_size", cfg_dict.get("n_embd", "N/A"))
+    num_heads = cfg_dict.get("num_attention_heads", cfg_dict.get("n_head", "N/A"))
+    max_pos = cfg_dict.get("max_position_embeddings", cfg_dict.get("max_seq_len", "N/A"))
+    torch_dtype = cfg_dict.get("torch_dtype", "N/A")
+
+    return {
+        "name": name_or_alias,
+        "repo_id": repo_id,
+        "architecture": arch,
+        "layers": num_layers,
+        "hidden_size": hidden_size,
+        "attention_heads": num_heads,
+        "context_length": max_pos,
+        "dtype": torch_dtype,
+    }

--- a/air_llm/setup.py
+++ b/air_llm/setup.py
@@ -45,4 +45,9 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    entry_points={
+        "console_scripts": [
+            "airllm=airllm.cli:main",
+        ],
+    },
 )


### PR DESCRIPTION
## Summary

Currently, running inference with AirLLM requires writing custom Python scripts to tokenize inputs, manage tensors on CUDA, invoke `.generate()`, and decode token IDs manually.

This PR introduces an **Ollama-like command-line interface and interactive chat REPL**, allowing users to chat with 70B+ models directly from the terminal without writing any boilerplate code.

## Key Features Added

### 1. Interactive Terminal Chat REPL (`airllm run <model>`)
- **Live Token Streaming**: Real-time token-by-token generation via `transformers.TextIteratorStreamer` on a background thread.
- **Multi-Turn Conversational Memory**: Retains dialogue context and automatically applies the model's chat template (`apply_chat_template`) with a graceful fallback.
- **Slash Commands**:
  - `/help`: Show command cheat sheet.
  - `/clear`: Reset conversational context.
  - `/system <prompt>`: Update system instructions on the fly.
  - `/history`: Display the message history of the current session.
  - `/stats`: Toggle generation speed display (`tokens/s`, latency, token count).
  - `/bye` or `/exit`: Cleanly exit the session.
- **Customization Options**: Supports `--compression 4bit|8bit`, `--device`, `--max-seq-len`, `--max-new-tokens`, `--system`, and `--hf-token`.

### 2. Model Management Commands
- **`airllm list` (or `airllm ls`)**: Scans HuggingFace and AirLLM storage to display local models, shard readiness, and formatted disk sizes.
- **`airllm pull <model>`**: Pre-downloads and shards a model ahead of time so it loads instantly when chatting.
- **`airllm show <model>`**: Inspects model architecture, layer count, hidden size, precision, and context window length.
- **`airllm rm <model>`**: Safely removes cached model layers and shards to free disk space.
- **`airllm aliases`**: Displays friendly short aliases for popular models.

### 3. Model Alias Registry
Users can specify friendly Ollama-style tags instead of remembering full HuggingFace repository paths (though any arbitrary HuggingFace repo ID or local checkpoint path remains supported):
- Llama 3 / 3.1 / 3.2 / 3.3: `llama3:70b`, `llama3.1:70b`, `llama3.1:405b`, `llama3.3:70b`, etc.
- DeepSeek: `deepseek-v3`, `deepseek-r1:70b`, `deepseek-r1:8b`, `deepseek-r1:1.5b`
- Qwen 2.5: `qwen2.5:72b`, `qwen2.5:32b`, `qwen2.5:14b`, `qwen2.5:7b`
- Mistral / Mixtral: `mistral:7b`, `mixtral:8x7b`

### 4. Setup & Entry Point
- Registered console script `airllm = airllm.cli:main` in `setup.py` so the `airllm` command is globally accessible after package installation.
- Added `__main__.py` to allow execution via `python -m airllm`.

## Zero New Dependencies
All CLI and streaming features are built using existing dependencies (`transformers>=4.49`, `torch>=2.4`) and the Python standard library. No new dependencies are introduced.

## Testing & Verification
- [x] Verified `airllm --help`, `airllm list`, `airllm show <model>`, `airllm aliases`.
- [x] Verified alias resolution logic against remote repos and local paths.
- [x] Tested streaming generator and interactive REPL state machine (`/clear`, `/stats`, `/bye`).
- [x] Verified packaging and installation with `pip install -e .`.
